### PR TITLE
Add the Access-Control-Allow-Origin response header when Origin present in request.

### DIFF
--- a/FiftyOne.Pipeline.Web.Shared/Services/ClientsidePropertyService.cs
+++ b/FiftyOne.Pipeline.Web.Shared/Services/ClientsidePropertyService.cs
@@ -160,7 +160,6 @@ namespace FiftyOne.Pipeline.Web.Shared.Services
             ServeContent(context, flowData, ContentType.Json);
         }
 
-
         private void ServeContent(IContextAdapter context, IFlowData flowData, ContentType contentType)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
@@ -250,11 +249,33 @@ namespace FiftyOne.Pipeline.Web.Shared.Services
                     new string[] {
                     hash,
                     }));
+                context.Response.SetHeader("Access-Control-Allow-Origin", GetAllowOrigins(context.Request).First());
             }
             catch (InvalidOperationException ex)
             {
                 _logger.LogWarning(ex, Messages.MessageJavaScriptCachingError);
             }
+        }
+
+        private static readonly string[] ORIGIN_HEADERS = { "Origin", "Referer" };
+
+        /// <summary>
+        /// Returns the value for the Access-Control-Allow-Origin response header. The best headers are used initially
+        /// and then if no specific value can be determined the wildcard * returned.
+        /// </summary>
+        /// <param name="request"></param>
+        /// <returns></returns>
+        private IEnumerable<string> GetAllowOrigins(IRequestAdapter request)
+        {
+            foreach (var headerName in ORIGIN_HEADERS)
+            {
+                var value = request.GetHeaderValue(headerName);
+                if (String.IsNullOrEmpty(value) == false)
+                {
+                    yield return value;
+                }
+            }
+            yield return "*";
         }
     }
 }

--- a/FiftyOne.Pipeline.Web.Shared/Services/ClientsidePropertyService.cs
+++ b/FiftyOne.Pipeline.Web.Shared/Services/ClientsidePropertyService.cs
@@ -249,7 +249,11 @@ namespace FiftyOne.Pipeline.Web.Shared.Services
                     new string[] {
                     hash,
                     }));
-                context.Response.SetHeader("Access-Control-Allow-Origin", GetAllowOrigins(context.Request).First());
+                var origin = GetAllowOrigin(context.Request);
+                if (origin != null)
+                {
+                    context.Response.SetHeader("Access-Control-Allow-Origin", origin);
+                }
             }
             catch (InvalidOperationException ex)
             {
@@ -257,25 +261,21 @@ namespace FiftyOne.Pipeline.Web.Shared.Services
             }
         }
 
-        private static readonly string[] ORIGIN_HEADERS = { "Origin", "Referer" };
-
         /// <summary>
-        /// Returns the value for the Access-Control-Allow-Origin response header. The best headers are used initially
-        /// and then if no specific value can be determined the wildcard * returned.
+        /// Returns the value for the Access-Control-Allow-Origin response header by inspecting the Origin header
+        /// of the request. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin for details associated
+        /// with the Origin header.
         /// </summary>
         /// <param name="request"></param>
         /// <returns></returns>
-        private IEnumerable<string> GetAllowOrigins(IRequestAdapter request)
+        private string GetAllowOrigin(IRequestAdapter request)
         {
-            foreach (var headerName in ORIGIN_HEADERS)
+            var value = request.GetHeaderValue("Origin");
+            if (String.IsNullOrEmpty(value) == false && "null".Equals(value) == false)
             {
-                var value = request.GetHeaderValue(headerName);
-                if (String.IsNullOrEmpty(value) == false)
-                {
-                    yield return value;
-                }
+                return value;
             }
-            yield return "*";
+            return null;
         }
     }
 }


### PR DESCRIPTION
Javascript and JSON responses will now include the Cross Origin Resource HTTP header Access-Control-Allow-Origin in the response when the Origin header is present in the request. This enables the Javascript and JSON end points to be used from origins other than the one hosting the service aiding the creation of services.