### PR TITLE
BUG/BUILD: The FiftyOne.Pipeline.Web package needs to be built with MSBuild in order to support .NET Framework.

### DIFF
--- a/ci/build-package.ps1
+++ b/ci/build-package.ps1
@@ -11,11 +11,22 @@ param(
 
 )
 
-$Solutions = @("FiftyOne.CloudRequestEngine.sln", "FiftyOne.Pipeline.Elements.sln", "FiftyOne.Pipeline.sln", "FiftyOne.Pipeline.Web.sln")
+$Solutions = @("FiftyOne.CloudRequestEngine.sln", "FiftyOne.Pipeline.Elements.sln", "FiftyOne.Pipeline.sln")
 
 foreach($Solution in $Solutions){
 
     ./dotnet/build-package-nuget.ps1 -RepoName $RepoName -Configuration "Release" -Version $Version -SolutionName $Solution -CodeSigningCert $Keys['CodeSigningCert'] -CodeSigningCertPassword $Keys['CodeSigningCertPassword'] -SearchPattern "^Project\(.*csproj"
 }
+
+# Now build the web package using the NuSpec file, as this is handled differently.
+
+$NuspecPath = [IO.Path]::Combine($pwd, $RepoName, "Web Integration", "FiftyOne.Pipeline.Web.nuspec")
+$CorePath = [IO.Path]::Combine($pwd, $RepoName, "Web Integration", "FiftyOne.Pipeline.Web")
+$SolutionPath = [IO.Path]::Combine($pwd, $RepoName, "FiftyOne.Pipeline.Web.sln")
+
+./environments/setup-msbuild.ps1
+./dotnet/build-project-core.ps1 -RepoName $RepoName -ProjectDir $CorePath -Name $Name -Configuration "Release"
+./dotnet/build-project-framework.ps1 -RepoName $RepoName -ProjectDir $SolutionPath -Name $Name -Configuration "Release" -Arch "Any CPU"
+./dotnet/build-package-nuspec.ps1 -RepoName $RepoName -Configuration "Release" -Version $Version -NuspecPath  $NuspecPath -CodeSigningCert $Keys['CodeSigningCert'] -CodeSigningCertPassword $Keys['CodeSigningCertPassword']
 
 exit $LASTEXITCODE

--- a/ci/build-package.ps1
+++ b/ci/build-package.ps1
@@ -22,11 +22,11 @@ foreach($Solution in $Solutions){
 
 $NuspecPath = [IO.Path]::Combine($pwd, $RepoName, "Web Integration", "FiftyOne.Pipeline.Web.nuspec")
 $CorePath = [IO.Path]::Combine($pwd, $RepoName, "Web Integration", "FiftyOne.Pipeline.Web")
-$SolutionPath = [IO.Path]::Combine($pwd, $RepoName, "FiftyOne.Pipeline.Web.sln")
+$WebSolutionPath = [IO.Path]::Combine($pwd, $RepoName, "FiftyOne.Pipeline.Web.sln")
 
 ./environments/setup-msbuild.ps1
 ./dotnet/build-project-core.ps1 -RepoName $RepoName -ProjectDir $CorePath -Name $Name -Configuration "Release"
-./dotnet/build-project-framework.ps1 -RepoName $RepoName -ProjectDir $SolutionPath -Name $Name -Configuration "Release" -Arch "Any CPU"
+./dotnet/build-project-framework.ps1 -RepoName $RepoName -ProjectDir $WebSolutionPath -Name $Name -Configuration "Release" -Arch "Any CPU"
 ./dotnet/build-package-nuspec.ps1 -RepoName $RepoName -Configuration "Release" -Version $Version -NuspecPath  $NuspecPath -CodeSigningCert $Keys['CodeSigningCert'] -CodeSigningCertPassword $Keys['CodeSigningCertPassword']
 
 exit $LASTEXITCODE


### PR DESCRIPTION
This has now been changed in the CI script, so the package will include DLLs for Framework.
Closes #27 