### PR TITLE
BUG: EvidenceKeyFilter was assigned before construction was complete.

### DIFF
--- a/FiftyOne.Pipeline.Core/FlowElements/Pipeline.cs
+++ b/FiftyOne.Pipeline.Core/FlowElements/Pipeline.cs
@@ -133,11 +133,12 @@ namespace FiftyOne.Pipeline.Core.FlowElements
                     {
                         if (_evidenceKeyFilter == null)
                         {
-                            _evidenceKeyFilter = new EvidenceKeyFilterAggregator();
+                            var evidenceKeyFilter = new EvidenceKeyFilterAggregator();
                             foreach (var filter in _flowElements.Select(e => e.EvidenceKeyFilter))
                             {
-                                _evidenceKeyFilter.AddFilter(filter);
+                                evidenceKeyFilter.AddFilter(filter);
                             }
+                            _evidenceKeyFilter = evidenceKeyFilter;
                         }
                     }
                 }


### PR DESCRIPTION
Within the lock, the private filter was assigned before being set up. The set up is now done with a local variable, then assigned to the private.