### PR TITLE
Prevent partially populate evidence key filter being return from pipeline

### DIFF
--- a/FiftyOne.Pipeline.Core/FlowElements/Pipeline.cs
+++ b/FiftyOne.Pipeline.Core/FlowElements/Pipeline.cs
@@ -133,11 +133,14 @@ namespace FiftyOne.Pipeline.Core.FlowElements
                     {
                         if (_evidenceKeyFilter == null)
                         {
-                            _evidenceKeyFilter = new EvidenceKeyFilterAggregator();
-                            foreach (var filter in _flowElements.Select(e => e.EvidenceKeyFilter))
+                            var evidenceKeyFilter = 
+                                new EvidenceKeyFilterAggregator();
+                            foreach (var filter in _flowElements.Select(e => 
+                                e.EvidenceKeyFilter))
                             {
-                                _evidenceKeyFilter.AddFilter(filter);
+                                evidenceKeyFilter.AddFilter(filter);
                             }
+                            _evidenceKeyFilter = evidenceKeyFilter;
                         }
                     }
                 }


### PR DESCRIPTION
BUG/MINOR: The double checked lock needs to set the shared instance of _evidenceKeyFilter as the very last statement to prevent a parallel task retrieving a partially populated instance.