### PR TITLE
BUG/TEST: The default data file configuration builder reused a static list for license keys.

### DIFF
--- a/FiftyOne.Pipeline.Engines/Configuration/DataFileConfiguration.cs
+++ b/FiftyOne.Pipeline.Engines/Configuration/DataFileConfiguration.cs
@@ -98,8 +98,7 @@ namespace FiftyOne.Pipeline.Engines.Configuration
         /// Note that the exact formatting of the query string is 
         /// controlled by the configured <see cref="UrlFormatter"/>.
         /// </summary>
-        public IReadOnlyList<string> DataUpdateLicenseKeys { get; set; } = 
-            Constants.DATA_FILE_DEFAULT_LICENSE_KEYS;
+        public IReadOnlyList<string> DataUpdateLicenseKeys { get; set; } = new List<string>();
 
         /// <summary>
         /// If true, a <see cref="FileSystemWatcher"/> will be created

--- a/FiftyOne.Pipeline.Engines/Configuration/DataFileConfigurationBuilderBase.cs
+++ b/FiftyOne.Pipeline.Engines/Configuration/DataFileConfigurationBuilderBase.cs
@@ -55,7 +55,7 @@ namespace FiftyOne.Pipeline.Engines.Configuration
         /// <summary>
         /// License keys to use when updating the Engine's data file.
         /// </summary>
-        protected List<string> DataUpdateLicenseKeys { get; private set; } = Constants.DATA_FILE_DEFAULT_LICENSE_KEYS;
+        protected List<string> DataUpdateLicenseKeys { get; private set; } = new List<string>();
 
         /// <summary>
         /// Constructor

--- a/FiftyOne.Pipeline.Engines/Constants.cs
+++ b/FiftyOne.Pipeline.Engines/Constants.cs
@@ -61,12 +61,6 @@ namespace FiftyOne.Pipeline.Engines
         public const bool DATA_FILE_DEFAULT_AUTO_UPDATES_ENABLED = true;
 
         /// <summary>
-        /// Default value for the list of license keys to use when checking for updates
-        /// for a data file.
-        /// </summary>
-        public static readonly List<string> DATA_FILE_DEFAULT_LICENSE_KEYS = new List<string>();
-
-        /// <summary>
         /// Default value for the flag that controls whether the file system watcher is 
         /// enabled for a data file or not.
         /// </summary>

--- a/FiftyOne.Pipeline.Engines/Constants.cs
+++ b/FiftyOne.Pipeline.Engines/Constants.cs
@@ -24,6 +24,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("FiftyOne.Pipeline.Engines.Tests")]
+[assembly: InternalsVisibleTo("FiftyOne.Pipeline.Engines.FiftyOne.Tests")]
 
 namespace FiftyOne.Pipeline.Engines
 {

--- a/Tests/FiftyOne.Pipeline.Engines.FiftyOne.Tests/Configuration/FiftyOneDataFileConfigurationBuilderTests.cs
+++ b/Tests/FiftyOne.Pipeline.Engines.FiftyOne.Tests/Configuration/FiftyOneDataFileConfigurationBuilderTests.cs
@@ -1,0 +1,30 @@
+﻿using FiftyOne.Pipeline.Engines.FiftyOne.Configuration;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace FiftyOne.Pipeline.Engines.FiftyOne.Tests.Configuration
+{
+    [TestClass]
+    public class FiftyOneDataFileConfigurationBuilderTests
+    {
+        /// <summary>
+        /// Check that when a new data file config builder is created, license keys
+        /// are not carried over from any previous instances.
+        /// This can happen if the list is initialized from a static constant which
+        /// is not explicitely copied to a new list.
+        /// </summary>
+        [TestMethod]
+        public void UrlNotReused()
+        {
+            // Arrange
+            var builder1 = new FiftyOneDataFileConfigurationBuilder();
+            builder1.SetDataUpdateLicenseKey("some test key");
+
+            // Act
+            var builder2 = new FiftyOneDataFileConfigurationBuilder();
+            var config2 = builder2.Build("some file", false);
+
+            // Assert
+            Assert.AreEqual(0, config2.DataUpdateLicenseKeys.Count);
+        }
+    }
+}

--- a/Tests/FiftyOne.Pipeline.Engines.FiftyOne.Tests/Data/UrlFormatterTests.cs
+++ b/Tests/FiftyOne.Pipeline.Engines.FiftyOne.Tests/Data/UrlFormatterTests.cs
@@ -120,8 +120,6 @@ namespace FiftyOne.Pipeline.Engines.FiftyOne.Tests.Data
             Assert.IsFalse(url2.Contains("license1"));
         }
 
-
-
         /// <summary>
         /// Check that license keys are used when constructing a download URL for
         /// an on premise engine. Also check that only the license key for that

--- a/Tests/FiftyOne.Pipeline.Engines.FiftyOne.Tests/Data/UrlFormatterTests.cs
+++ b/Tests/FiftyOne.Pipeline.Engines.FiftyOne.Tests/Data/UrlFormatterTests.cs
@@ -1,0 +1,223 @@
+﻿using FiftyOne.Common.TestHelpers;
+using FiftyOne.Common.Wrappers.IO;
+using FiftyOne.Pipeline.Engines.Configuration;
+using FiftyOne.Pipeline.Engines.Data;
+using FiftyOne.Pipeline.Engines.FiftyOne.Data;
+using FiftyOne.Pipeline.Engines.FiftyOne.FlowElements;
+using FiftyOne.Pipeline.Engines.FlowElements;
+using FiftyOne.Pipeline.Engines.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace FiftyOne.Pipeline.Engines.FiftyOne.Tests.Data
+{
+    [TestClass]
+    public class UrlFormatterTests
+    {
+        private TestLogger<DataUpdateService> _logger;
+        private Mock<IFileWrapper> _fileWrapper;
+        private Mock<IDirectoryWrapper> _directoryWarpper;
+        private Mock<IFileSystem> _fileSystem;
+        private Mock<Func<TimerCallback, object, TimeSpan, Timer>> _timerFactory;
+        private Mock<MockHttpMessageHandler> _httpHandler;
+        private HttpClient _httpClient;
+        private DataUpdateService _dataUpdate;
+
+        /// <summary>
+        /// Initialise the test instance.
+        /// </summary>
+        [TestInitialize]
+        public void Init()
+        {
+            // Create mocks
+            _logger = new TestLogger<DataUpdateService>();
+            _fileWrapper = new Mock<IFileWrapper>();
+            _directoryWarpper = new Mock<IDirectoryWrapper>();
+            _fileSystem = new Mock<IFileSystem>();
+            _fileSystem.Setup(f => f.File).Returns(_fileWrapper.Object);
+            _fileSystem.Setup(f => f.Directory).Returns(_directoryWarpper.Object);
+            _timerFactory = new Mock<Func<TimerCallback, object, TimeSpan, Timer>>();
+
+            // Create the HttpClient using the mock handler
+            _httpHandler = new Mock<MockHttpMessageHandler>() { CallBase = true };
+            _httpClient = new HttpClient(_httpHandler.Object);
+
+            // Configure the mock handler to return an 'OK' status code.
+            _httpHandler.Setup(h => h.Send(It.IsAny<HttpRequestMessage>()))
+                .Callback((HttpRequestMessage request) =>
+                { })
+                .Returns(new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+                {
+                    Content = new StringContent("<empty />", Encoding.UTF8, "application/xml"),
+                });
+
+            // Create the data update service
+            _dataUpdate = new DataUpdateService(
+                _logger,
+                _httpClient,
+                _fileSystem.Object,
+                _timerFactory.Object);
+
+        }
+
+        /// <summary>
+        /// Check that license keys are used when constructing a download URL for
+        /// an on premise engine. Also check that only the license key for that
+        /// data file is used.
+        /// </summary>
+        [TestMethod]
+        public void FiftyOneUrlFormatter_FormattedUri_MultipleEngines()
+        {
+            Mock<IFiftyOneAspectEngine> engine1 = new Mock<IFiftyOneAspectEngine>();
+            engine1.Setup(e => e.GetDataDownloadType(It.IsAny<string>())).Returns("test");
+            var config1 = new DataFileConfiguration()
+            {
+                AutomaticUpdatesEnabled = true,
+                FileSystemWatcherEnabled = false,
+                LicenseKeyRequiredForUpdates = true,
+                DataUpdateLicenseKeys = new List<string>() { "license1" },
+                DataUpdateUrl = "https://download.test.com",
+                UrlFormatter = new FiftyOneUrlFormatter()
+            };
+            var file1 = new FiftyOneDataFile(typeof(IOnPremiseAspectEngine))
+            {
+                Engine = engine1.Object,
+                Configuration = config1,
+                DataDownloadType = "test"
+            };
+            Mock<IFiftyOneAspectEngine> engine2 = new Mock<IFiftyOneAspectEngine>();
+            engine2.Setup(e => e.GetDataDownloadType(It.IsAny<string>())).Returns("test");
+            var config2 = new DataFileConfiguration()
+            {
+                AutomaticUpdatesEnabled = true,
+                FileSystemWatcherEnabled = false,
+                LicenseKeyRequiredForUpdates = true,
+                DataUpdateLicenseKeys = new List<string>() { "license2" },
+                DataUpdateUrl = "https://download.test.com",
+                UrlFormatter = new FiftyOneUrlFormatter()
+            };
+            var file2 = new FiftyOneDataFile(typeof(IOnPremiseAspectEngine))
+            {
+                Engine = engine2.Object,
+                Configuration = config2,
+                DataDownloadType = "test"
+            };
+            _dataUpdate.RegisterDataFile(file1);
+            _dataUpdate.RegisterDataFile(file2);
+
+            var url1 = file1.FormattedUri.AbsoluteUri;
+            var url2 = file2.FormattedUri.AbsoluteUri;
+            Assert.IsTrue(url1.Contains("license1"));
+            Assert.IsFalse(url1.Contains("license2"));
+            Assert.IsTrue(url2.Contains("license2"));
+            Assert.IsFalse(url2.Contains("license1"));
+        }
+
+
+
+        /// <summary>
+        /// Check that license keys are used when constructing a download URL for
+        /// an on premise engine. Also check that only the license key for that
+        /// data file is used.
+        /// </summary>
+        [TestMethod]
+        public void FiftyOneUrlFormatter_RequestedUrl_MultipleEngines()
+        {
+            ConfigureTimerImmediateCallbackOnce();
+            Mock<IFiftyOneAspectEngine> engine1 = new Mock<IFiftyOneAspectEngine>();
+            engine1.Setup(e => e.GetDataDownloadType(It.IsAny<string>())).Returns("test");
+            engine1.SetupGet(e => e.TempDataDirPath).Returns("temp");
+            var config1 = new DataFileConfiguration()
+            {
+                AutomaticUpdatesEnabled = true,
+                FileSystemWatcherEnabled = false,
+                LicenseKeyRequiredForUpdates = true,
+                DataUpdateLicenseKeys = new List<string>() { "license1" },
+                DataUpdateUrl = "https://download.test.com",
+                CreateTempCopy = true,
+                UrlFormatter = new FiftyOneUrlFormatter(),
+                DataFilePath = "test/test.hash"
+            };
+            var file1 = new FiftyOneDataFile(typeof(IOnPremiseAspectEngine))
+            {
+                Engine = engine1.Object,
+                Configuration = config1,
+                DataDownloadType = "test"
+            };
+            Mock<IFiftyOneAspectEngine> engine2 = new Mock<IFiftyOneAspectEngine>();
+            engine2.Setup(e => e.GetDataDownloadType(It.IsAny<string>())).Returns("test");
+            var config2 = new DataFileConfiguration()
+            {
+                AutomaticUpdatesEnabled = true,
+                FileSystemWatcherEnabled = false,
+                LicenseKeyRequiredForUpdates = true,
+                DataUpdateLicenseKeys = new List<string>() { "license2" },
+                DataUpdateUrl = "https://download.test.com",
+                CreateTempCopy = true,
+                UrlFormatter = new FiftyOneUrlFormatter()
+            };
+            var file2 = new FiftyOneDataFile(typeof(IOnPremiseAspectEngine))
+            {
+                Engine = engine2.Object,
+                Configuration = config2,
+                DataDownloadType = "test"
+            };
+            ManualResetEventSlim completeFlag = new ManualResetEventSlim(false);
+            _dataUpdate.CheckForUpdateComplete += (object sender, DataUpdateCompleteArgs e) =>
+            {
+                if (e.DataFile.Equals(file1))
+                {
+                    completeFlag.Set();
+                }
+            };
+            _dataUpdate.RegisterDataFile(file1);
+            _dataUpdate.RegisterDataFile(file2);
+            // Wait until processing is complete.
+            completeFlag.Wait(10000);
+
+            // Assert
+            _httpHandler.Verify(h => h.Send(It.IsAny<HttpRequestMessage>()),
+                Times.Once);
+            _httpHandler.Verify(h => h.Send(It.Is<HttpRequestMessage>(m =>
+                m.RequestUri.Query.Contains("license1"))),
+                Times.Once);
+            _httpHandler.Verify(h => h.Send(It.Is<HttpRequestMessage>(m =>
+                m.RequestUri.Query.Contains("license2"))),
+                Times.Never);
+        }
+
+        private void ConfigureTimerImmediateCallbackOnce()
+        {
+            // Configure the timer factory to return a timer that will
+            // execute the callback immediately
+            int counter = 0;
+            _timerFactory.Setup(f => f(
+                It.IsAny<TimerCallback>(),
+                It.IsAny<object>(),
+                It.IsAny<TimeSpan>()))
+                .Returns((TimerCallback callback, object state, TimeSpan interval) =>
+                {
+                    // Only return the timer of the first call.
+                    // For subsequent calls (when the engine is registered 
+                    // again following a successful update) just return
+                    // null to prevent repeated updates.
+                    if (counter == 0)
+                    {
+                        counter++;
+                        return new Timer(callback, state, 0, Timeout.Infinite);
+                    }
+                    else
+                    {
+                        return null;
+                    }
+                });
+        }
+    }
+}


### PR DESCRIPTION
BUG/TEST: The default data file configuration builder reused a static list for license keys.
This means that when mutiple builders are used, they are all accessing the same static list. So license keys are shared across engines. This is not the correct behaviour, but will usually not be noticed as one engine is more common.
Also added a test to confirm this is fixed.

TEST: Added tests for update URL formatting. 

closes #45 