### PR TITLE
Lazify cloud request engine properties

### DIFF
--- a/FiftyOne.Pipeline.CloudRequestEngine/CloudRequestException.cs
+++ b/FiftyOne.Pipeline.CloudRequestEngine/CloudRequestException.cs
@@ -85,5 +85,21 @@ namespace FiftyOne.Pipeline.CloudRequestEngine
             HttpStatusCode = httpStatusCode;
             _responseHeaders = responseHeaders;
         }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="httpStatusCode"></param>
+        /// <param name="responseHeaders"></param>
+        /// <param name="innerException"></param>
+        public CloudRequestException(string message,
+            int httpStatusCode,
+            Dictionary<string, string> responseHeaders,
+            Exception innerException) : base(message, innerException)
+        {
+            HttpStatusCode = httpStatusCode;
+            _responseHeaders = responseHeaders;
+        }
     }
 }

--- a/FiftyOne.Pipeline.CloudRequestEngine/FlowElements/CloudAspectEngineBase.cs
+++ b/FiftyOne.Pipeline.CloudRequestEngine/FlowElements/CloudAspectEngineBase.cs
@@ -28,9 +28,11 @@ using FiftyOne.Pipeline.Core.FlowElements;
 using FiftyOne.Pipeline.Engines.Data;
 using FiftyOne.Pipeline.Engines.FlowElements;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
 
@@ -169,18 +171,25 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.FlowElements
                     {
                         if (_aspectProperties == null)
                         {
-                            if (LoadAspectProperties(
-                                RequestEngine.GetInstance()) == false)
+                            var engineInstance = RequestEngine.GetInstance();
+                            try
                             {
-                                throw new PipelineException(string.Format(
-                                    CultureInfo.InvariantCulture, 
-                                    Messages.ExceptionFailedToLoadProperties,
-                                    ElementDataKey));
+                                if (LoadAspectProperties(engineInstance) == false)
+                                {
+                                    throw new PipelineException(string.Format(
+                                        CultureInfo.InvariantCulture,
+                                        Messages.ExceptionFailedToLoadProperties,
+                                        ElementDataKey));
+                                }
+                            }
+                            catch (CloudRequestException)
+                            {
+                                // ignore server errors, properties will be requested again
                             }
                         }
                     }
                 }
-                return _aspectProperties;
+                return _aspectProperties ?? new IAspectPropertyMetaData[0];
             }
         }
 

--- a/FiftyOne.Pipeline.CloudRequestEngine/FlowElements/CloudAspectEngineBase.cs
+++ b/FiftyOne.Pipeline.CloudRequestEngine/FlowElements/CloudAspectEngineBase.cs
@@ -169,25 +169,18 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.FlowElements
                     {
                         if (_aspectProperties == null)
                         {
-                            var engineInstance = RequestEngine.GetInstance();
-                            try
+                            if (LoadAspectProperties(
+                                RequestEngine.GetInstance()) == false)
                             {
-                                if (LoadAspectProperties(engineInstance) == false)
-                                {
-                                    throw new PipelineException(string.Format(
-                                        CultureInfo.InvariantCulture,
-                                        Messages.ExceptionFailedToLoadProperties,
-                                        ElementDataKey));
-                                }
-                            }
-                            catch (CloudRequestException)
-                            {
-                                // ignore server errors, properties will be requested again
+                                throw new PipelineException(string.Format(
+                                    CultureInfo.InvariantCulture, 
+                                    Messages.ExceptionFailedToLoadProperties,
+                                    ElementDataKey));
                             }
                         }
                     }
                 }
-                return _aspectProperties ?? new IAspectPropertyMetaData[0];
+                return _aspectProperties;
             }
         }
 

--- a/FiftyOne.Pipeline.CloudRequestEngine/FlowElements/CloudAspectEngineBase.cs
+++ b/FiftyOne.Pipeline.CloudRequestEngine/FlowElements/CloudAspectEngineBase.cs
@@ -185,6 +185,12 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.FlowElements
         }
 
         /// <summary>
+        /// Provide an implementation for the non-generic, 
+        /// aspect-specific version of the meta-data property.
+        /// </summary>
+        public override bool HasLoadedProperties { get { return _aspectProperties != null; } }
+
+        /// <summary>
         /// Constructor
         /// </summary>
         /// <param name="logger">

--- a/FiftyOne.Pipeline.CloudRequestEngine/FlowElements/CloudAspectEngineBase.cs
+++ b/FiftyOne.Pipeline.CloudRequestEngine/FlowElements/CloudAspectEngineBase.cs
@@ -28,11 +28,9 @@ using FiftyOne.Pipeline.Core.FlowElements;
 using FiftyOne.Pipeline.Engines.Data;
 using FiftyOne.Pipeline.Engines.FlowElements;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
 

--- a/FiftyOne.Pipeline.CloudRequestEngine/FlowElements/CloudAspectEngineBase.cs
+++ b/FiftyOne.Pipeline.CloudRequestEngine/FlowElements/CloudAspectEngineBase.cs
@@ -169,13 +169,20 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.FlowElements
                     {
                         if (_aspectProperties == null)
                         {
-                            if (LoadAspectProperties(
-                                RequestEngine.GetInstance()) == false)
+                            var engineInstance = RequestEngine.GetInstance();
+                            try
                             {
-                                throw new PipelineException(string.Format(
-                                    CultureInfo.InvariantCulture, 
-                                    Messages.ExceptionFailedToLoadProperties,
-                                    ElementDataKey));
+                                if (LoadAspectProperties(engineInstance) == false)
+                                {
+                                    throw new PipelineException(string.Format(
+                                        CultureInfo.InvariantCulture,
+                                        Messages.ExceptionFailedToLoadProperties,
+                                        ElementDataKey));
+                                }
+                            }
+                            catch (CloudRequestException ex)
+                            {
+                                throw new PropertiesNotYetLoadedException("Failed to request properties from the cloud.", ex);
                             }
                         }
                     }

--- a/FiftyOne.Pipeline.CloudRequestEngine/FlowElements/CloudRequestEngine.cs
+++ b/FiftyOne.Pipeline.CloudRequestEngine/FlowElements/CloudRequestEngine.cs
@@ -302,7 +302,15 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.FlowElements
 
             if (hasData && checkForErrorMessages)
             {
-                var jObj = JObject.Parse(jsonResult);
+                JObject jObj;
+                try
+                {
+                    jObj = JObject.Parse(jsonResult);
+                }
+                catch (JsonReaderException ex)
+                {
+                    throw new CloudRequestException("Failed to parse server's response as JSON", ex);
+                }
                 var hasErrors = jObj.ContainsKey("errors");
                 hasData = hasErrors ?
                     jObj.Values().Count() > 1 :

--- a/FiftyOne.Pipeline.CloudRequestEngine/FlowElements/CloudRequestEngine.cs
+++ b/FiftyOne.Pipeline.CloudRequestEngine/FlowElements/CloudRequestEngine.cs
@@ -193,11 +193,23 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.FlowElements
             {
                 if (_evidenceKeyFilter == null)
                 {
-                    GetCloudEvidenceKeys();
+                    lock (_evidenceKeyFilterLock)
+                    {
+                        if (_evidenceKeyFilter == null)
+                        {
+                            _evidenceKeyFilter = GetCloudEvidenceKeys();
+                        }
+                    }
                 }
                 return _evidenceKeyFilter;
             }
         }
+
+        /// <summary>
+        /// Lock used when constructing an EvidenceKeyFilter.
+        /// </summary>
+        private readonly object _evidenceKeyFilterLock = new object();
+
 
         /// <summary>
         /// A collection of the properties that the cloud service can
@@ -209,11 +221,22 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.FlowElements
             {
                 if (_publicProperties == null)
                 {
-                    GetCloudProperties();
+                    lock (_publicPropertiesLock)
+                    {
+                        if (_publicProperties == null)
+                        {
+                            _publicProperties = GetCloudProperties();
+                        }
+                    }
                 }
                 return _publicProperties;
             }
         }
+
+        /// <summary>
+        /// Lock used when constructing PublicProperties.
+        /// </summary>
+        private readonly object _publicPropertiesLock = new object();
 
         /// <summary>
         /// Send evidence to the cloud and get back a JSON result.
@@ -480,7 +503,7 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.FlowElements
         /// <summary>
         /// Get the properties that are available from the cloud service.
         /// </summary>
-        private void GetCloudProperties()
+        private Dictionary<string, ProductMetaData> GetCloudProperties()
         {
             string jsonResult = string.Empty;
 
@@ -496,7 +519,7 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.FlowElements
                 var accessiblePropertyData = JsonConvert
                     .DeserializeObject<LicencedProducts>(jsonResult);
 
-                _publicProperties = accessiblePropertyData.Products;
+                return accessiblePropertyData.Products;
             }
             else
             {
@@ -508,7 +531,7 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.FlowElements
         /// <summary>
         /// Get the evidence keys that are required by the cloud service.
         /// </summary>
-        private void GetCloudEvidenceKeys()
+        private IEvidenceKeyFilter GetCloudEvidenceKeys()
         {
             string jsonResult = string.Empty;
 
@@ -526,7 +549,7 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.FlowElements
                 var evidenceKeys = JsonConvert
                     .DeserializeObject<List<string>>(jsonResult);
 
-                _evidenceKeyFilter = new EvidenceKeyFilterWhitelist(evidenceKeys);
+                return new EvidenceKeyFilterWhitelist(evidenceKeys);
             }
             else
             {

--- a/FiftyOne.Pipeline.CloudRequestEngine/FlowElements/CloudRequestEngine.cs
+++ b/FiftyOne.Pipeline.CloudRequestEngine/FlowElements/CloudRequestEngine.cs
@@ -44,7 +44,7 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.FlowElements
         "CA1724:Type names should not match namespaces",
         Justification = "This would be a breaking change so will be " +
         "addressed in a future version.")]
-    public class CloudRequestEngine : 
+    public class CloudRequestEngine :
         AspectEngineBase<CloudRequestData, IAspectPropertyMetaData>,
         ICloudRequestEngine
     {
@@ -112,8 +112,8 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.FlowElements
         /// Thrown if a required parameter is null.
         /// </exception>
         public CloudRequestEngine(
-            ILogger<AspectEngineBase<CloudRequestData, IAspectPropertyMetaData>> logger, 
-            Func<IPipeline, FlowElementBase<CloudRequestData, IAspectPropertyMetaData>, 
+            ILogger<AspectEngineBase<CloudRequestData, IAspectPropertyMetaData>> logger,
+            Func<IPipeline, FlowElementBase<CloudRequestData, IAspectPropertyMetaData>,
                 CloudRequestData> aspectDataFactory,
             HttpClient httpClient,
             string dataEndpoint,
@@ -123,7 +123,7 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.FlowElements
             string evidenceKeysEndpoint,
             int timeout,
             List<string> requestedProperties,
-            string cloudRequestOrigin = null) 
+            string cloudRequestOrigin = null)
             : base(logger, aspectDataFactory)
         {
             if (httpClient == null) throw new ArgumentNullException(nameof(httpClient));
@@ -147,9 +147,6 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.FlowElements
                 {
                     _httpClient.Timeout = new TimeSpan(0, 0, 0, 0, -1);
                 }
-
-                GetCloudProperties();
-                GetCloudEvidenceKeys();
 
                 _propertyMetaData = new List<IAspectPropertyMetaData>()
                 {
@@ -191,14 +188,32 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.FlowElements
         /// be populated after a call to the cloud service as part of 
         /// object initialization.
         /// </summary>
-        public override IEvidenceKeyFilter EvidenceKeyFilter => _evidenceKeyFilter;
+        public override IEvidenceKeyFilter EvidenceKeyFilter {
+            get
+            {
+                if (_evidenceKeyFilter == null)
+                {
+                    GetCloudEvidenceKeys();
+                }
+                return _evidenceKeyFilter;
+            }
+        }
 
         /// <summary>
         /// A collection of the properties that the cloud service can
         /// populate in the JSON response.
         /// Keyed on property name.
         /// </summary>
-        public IReadOnlyDictionary<string, ProductMetaData> PublicProperties => _publicProperties;
+        public IReadOnlyDictionary<string, ProductMetaData> PublicProperties {
+            get
+            {
+                if (_publicProperties == null)
+                {
+                    GetCloudProperties();
+                }
+                return _publicProperties;
+            }
+        }
 
         /// <summary>
         /// Send evidence to the cloud and get back a JSON result.

--- a/FiftyOne.Pipeline.Core/Constants.cs
+++ b/FiftyOne.Pipeline.Core/Constants.cs
@@ -20,6 +20,8 @@
  * such notice(s) shall fulfill the requirements of that article.
  * ********************************************************************* */
 
+using System;
+
 namespace FiftyOne.Pipeline.Core
 {
     /// <summary>
@@ -107,6 +109,13 @@ namespace FiftyOne.Pipeline.Core
         /// The default value for the flag that controls whether the pipeline will allow exceptions
         /// from flow elements to bubble up to the caller, or be caught and logged.
         /// </summary>
-        public const bool PIPELINE_BUILDER_DEFAULT_AUTO_SUPRESS_PROCESS_EXCEPTION = false;
+        [ObsoleteAttribute("This constant is obsolete. Use " + nameof(PIPELINE_BUILDER_DEFAULT_AUTO_SUPRESS_PROCESS_EXCEPTIONS) + " instead.", false)]
+        public const bool PIPELINE_BUILDER_DEFAULT_AUTO_SUPRESS_PROCESS_EXCEPTION = PIPELINE_BUILDER_DEFAULT_AUTO_SUPRESS_PROCESS_EXCEPTIONS;
+
+        /// <summary>
+        /// The default value for the flag that controls whether the pipeline will allow exceptions
+        /// from flow elements to bubble up to the caller, or be caught and logged.
+        /// </summary>
+        public const bool PIPELINE_BUILDER_DEFAULT_AUTO_SUPRESS_PROCESS_EXCEPTIONS = false;
     }
 }

--- a/FiftyOne.Pipeline.Core/Exceptions/PropertiesNotYetLoadedException.cs
+++ b/FiftyOne.Pipeline.Core/Exceptions/PropertiesNotYetLoadedException.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace FiftyOne.Pipeline.Core.Exceptions
+{
+    /// <summary>
+    /// Thrown by <see cref="FlowElements.IFlowElement.Properties"/> to indicate
+    /// that properties are not available yet
+    /// but MAY(!) be re-requested later.
+    /// </summary>
+    public class PropertiesNotYetLoadedException: PipelineException
+    {
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        public PropertiesNotYetLoadedException() : base() { }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="message">
+        /// The exception message
+        /// </param>
+        public PropertiesNotYetLoadedException(
+            string message)
+            : base(message)
+        { }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="message">
+        /// The exception message
+        /// </param>
+        /// <param name="innerException">
+        /// The inner exception that triggered this exception.
+        /// </param>
+        public PropertiesNotYetLoadedException(
+            string message,
+            Exception innerException) :
+            base(message, innerException)
+        { }
+    }
+}

--- a/FiftyOne.Pipeline.Core/FlowElements/IFlowElement.cs
+++ b/FiftyOne.Pipeline.Core/FlowElements/IFlowElement.cs
@@ -76,6 +76,10 @@ namespace FiftyOne.Pipeline.Core.FlowElements
         /// <summary>
         /// Details of the properties that this element can populate 
         /// </summary>
+        /// <exception cref="Exceptions.PropertiesNotYetLoadedException">
+        /// Thrown if properties are not available yet
+        /// but MAY(!) be re-requested later.
+        /// </exception>
         IList<IElementPropertyMetaData> Properties { get; }
     }
 

--- a/FiftyOne.Pipeline.Core/FlowElements/IFlowElement.cs
+++ b/FiftyOne.Pipeline.Core/FlowElements/IFlowElement.cs
@@ -74,11 +74,20 @@ namespace FiftyOne.Pipeline.Core.FlowElements
         bool IsDisposed { get; }
 
         /// <summary>
-        /// Details of the properties that this element can populate 
+        /// Details of the properties that this element can populate.
+        /// MUST be semantically persistent (i.e. cacheable by IPipeline).
+        /// WILL be called from within the pipeline during initialization.
         /// </summary>
         /// <exception cref="Exceptions.PropertiesNotYetLoadedException">
         /// Thrown if properties are not available yet
         /// but MAY(!) be re-requested later.
+        /// Means the component MIGHT still recover from the error
+        /// and return populated value sometime later.
+        /// </exception>
+        /// <exception cref="Exceptions.PipelineException">
+        /// Thrown when the component detects UNRECOVERABLE errors.
+        /// If thrown on the first call to this component,
+        /// WILL propagate through pipeline's constructor.
         /// </exception>
         IList<IElementPropertyMetaData> Properties { get; }
     }

--- a/FiftyOne.Pipeline.Core/FlowElements/IPipeline.cs
+++ b/FiftyOne.Pipeline.Core/FlowElements/IPipeline.cs
@@ -61,6 +61,13 @@ namespace FiftyOne.Pipeline.Core.FlowElements
         bool IsDisposed { get; }
 
         /// <summary>
+        /// Control field that indicates if the Pipeline will throw an
+        /// aggregate exception during processing or suppress it and ignore the
+        /// exceptions added to <see cref="IFlowData.Errors"/>.
+        /// </summary>
+        bool SuppressProcessExceptions { get; }
+
+        /// <summary>
         /// Check if the pipeline contains an instance of <typeparamref name="TExpectedElement"/>
         /// that will be executed after <typeparamref name="TElement"/>.
         /// </summary>

--- a/FiftyOne.Pipeline.Core/FlowElements/ParallelElements.cs
+++ b/FiftyOne.Pipeline.Core/FlowElements/ParallelElements.cs
@@ -87,8 +87,17 @@ namespace FiftyOne.Pipeline.Core.FlowElements
                 if (_evidenceKeyFilter == null)
                 {
                     _evidenceKeyFilter = new EvidenceKeyFilterAggregator();
-                    foreach (var filter in _flowElements.Select(e => e.EvidenceKeyFilter))
+                    foreach (var nextElement in _flowElements)
                     {
+                        IEvidenceKeyFilter filter;
+                        try
+                        {
+                            filter = nextElement.EvidenceKeyFilter;
+                        }
+                        catch
+                        {
+                            continue;
+                        }
                         _evidenceKeyFilter.AddFilter(filter);
                     }
                 }

--- a/FiftyOne.Pipeline.Core/FlowElements/ParallelElements.cs
+++ b/FiftyOne.Pipeline.Core/FlowElements/ParallelElements.cs
@@ -87,17 +87,8 @@ namespace FiftyOne.Pipeline.Core.FlowElements
                 if (_evidenceKeyFilter == null)
                 {
                     _evidenceKeyFilter = new EvidenceKeyFilterAggregator();
-                    foreach (var nextElement in _flowElements)
+                    foreach (var filter in _flowElements.Select(e => e.EvidenceKeyFilter))
                     {
-                        IEvidenceKeyFilter filter;
-                        try
-                        {
-                            filter = nextElement.EvidenceKeyFilter;
-                        }
-                        catch
-                        {
-                            continue;
-                        }
                         _evidenceKeyFilter.AddFilter(filter);
                     }
                 }

--- a/FiftyOne.Pipeline.Core/FlowElements/Pipeline.cs
+++ b/FiftyOne.Pipeline.Core/FlowElements/Pipeline.cs
@@ -269,6 +269,13 @@ namespace FiftyOne.Pipeline.Core.FlowElements
         /// The <see cref="IFlowData"/> that contains the evidence and will
         /// allow the user to access the results.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if a required parameter is null.
+        /// </exception>
+        /// <exception cref="AggregateException">
+        /// Thrown if an error occurred during processing, 
+        /// unless <see ref="SuppressProcessExceptions"/> is true.
+        /// </exception>
         public void Process(IFlowData data)
         {
             if(data == null)

--- a/FiftyOne.Pipeline.Core/FlowElements/Pipeline.cs
+++ b/FiftyOne.Pipeline.Core/FlowElements/Pipeline.cs
@@ -502,7 +502,7 @@ namespace FiftyOne.Pipeline.Core.FlowElements
                     {
                         elementProps = element.Properties;
                     }
-                    catch (PipelineException)
+                    catch (PropertiesNotYetLoadedException)
                     {
                         hadFailures = true;
                         continue;

--- a/FiftyOne.Pipeline.Core/FlowElements/Pipeline.cs
+++ b/FiftyOne.Pipeline.Core/FlowElements/Pipeline.cs
@@ -176,6 +176,13 @@ namespace FiftyOne.Pipeline.Core.FlowElements
         }
 
         /// <summary>
+        /// Control field that indicates if the Pipeline will throw an
+        /// aggregate exception during processing or suppress it and ignore the
+        /// exceptions added to <see cref="IFlowData.Errors"/>.
+        /// </summary>
+        public bool SuppressProcessExceptions => _suppressProcessExceptions;
+
+        /// <summary>
         /// Get a read only list of the flow elements that are part of this 
         /// pipeline.
         /// </summary>
@@ -301,7 +308,7 @@ namespace FiftyOne.Pipeline.Core.FlowElements
             // suppressed, then throw an aggregate exception.
             if (data.Errors != null &&
                 data.Errors.Count > 0 &&
-                _suppressProcessExceptions == false)
+                SuppressProcessExceptions == false)
             {
                 throw new AggregateException(data.Errors
                     .Where(e => e.ShouldThrow == true)

--- a/FiftyOne.Pipeline.Core/FlowElements/Pipeline.cs
+++ b/FiftyOne.Pipeline.Core/FlowElements/Pipeline.cs
@@ -135,17 +135,9 @@ namespace FiftyOne.Pipeline.Core.FlowElements
                         {
                             var evidenceKeyFilter = 
                                 new EvidenceKeyFilterAggregator();
-                            foreach (var nextElement in _flowElements)
+                            foreach (var filter in _flowElements.Select(e => 
+                                e.EvidenceKeyFilter))
                             {
-                                IEvidenceKeyFilter filter;
-                                try
-                                {
-                                    filter = nextElement.EvidenceKeyFilter;
-                                }
-                                catch
-                                {
-                                    continue;
-                                }
                                 evidenceKeyFilter.AddFilter(filter);
                             }
                             _evidenceKeyFilter = evidenceKeyFilter;
@@ -478,16 +470,7 @@ namespace FiftyOne.Pipeline.Core.FlowElements
                                 StringComparer.OrdinalIgnoreCase);
                     }
                     var availableElementProperties = dictionary[element.ElementDataKey];
-                    IList<IElementPropertyMetaData> elementProps;
-                    try
-                    {
-                        elementProps = element.Properties;
-                    }
-                    catch
-                    {
-                        continue;
-                    }
-                    foreach (var property in elementProps.Where(p => p.Available))
+                    foreach (var property in element.Properties.Where(p => p.Available))
                     {
                         if (availableElementProperties.ContainsKey(property.Name) == false)
                         {

--- a/FiftyOne.Pipeline.Core/FlowElements/Pipeline.cs
+++ b/FiftyOne.Pipeline.Core/FlowElements/Pipeline.cs
@@ -228,7 +228,9 @@ namespace FiftyOne.Pipeline.Core.FlowElements
         private object _elementAvailablePropertiesLock = new object();
 
         /// <summary>
-        /// Constructor
+        /// Constructor.
+        /// Calls back to each element via <see cref="IFlowElement.Properties"/>,
+        /// allowing them to perform some validations and throw.
         /// </summary>
         /// <param name="logger">
         /// Used for logging.
@@ -249,6 +251,11 @@ namespace FiftyOne.Pipeline.Core.FlowElements
         /// If true then Pipeline will suppress exceptions added to
         /// <see cref="IFlowData.Errors"/>.
         /// </param>
+        /// <exception cref="PipelineException">
+        /// Thrown by the flow element(s) detecting UNRECOVERABLE errors.
+        /// In case of compromised pipeline integrity
+        /// <see cref="PipelineConfigurationException"/> may be used.
+        /// </exception>
         internal Pipeline(
             ILogger<Pipeline> logger,
             Func<IPipelineInternal, IFlowData> flowDataFactory,

--- a/FiftyOne.Pipeline.Core/FlowElements/Pipeline.cs
+++ b/FiftyOne.Pipeline.Core/FlowElements/Pipeline.cs
@@ -135,9 +135,17 @@ namespace FiftyOne.Pipeline.Core.FlowElements
                         {
                             var evidenceKeyFilter = 
                                 new EvidenceKeyFilterAggregator();
-                            foreach (var filter in _flowElements.Select(e => 
-                                e.EvidenceKeyFilter))
+                            foreach (var nextElement in _flowElements)
                             {
+                                IEvidenceKeyFilter filter;
+                                try
+                                {
+                                    filter = nextElement.EvidenceKeyFilter;
+                                }
+                                catch
+                                {
+                                    continue;
+                                }
                                 evidenceKeyFilter.AddFilter(filter);
                             }
                             _evidenceKeyFilter = evidenceKeyFilter;
@@ -470,7 +478,16 @@ namespace FiftyOne.Pipeline.Core.FlowElements
                                 StringComparer.OrdinalIgnoreCase);
                     }
                     var availableElementProperties = dictionary[element.ElementDataKey];
-                    foreach (var property in element.Properties.Where(p => p.Available))
+                    IList<IElementPropertyMetaData> elementProps;
+                    try
+                    {
+                        elementProps = element.Properties;
+                    }
+                    catch
+                    {
+                        continue;
+                    }
+                    foreach (var property in elementProps.Where(p => p.Available))
                     {
                         if (availableElementProperties.ContainsKey(property.Name) == false)
                         {

--- a/FiftyOne.Pipeline.Core/FlowElements/PipelineBuilderBase.cs
+++ b/FiftyOne.Pipeline.Core/FlowElements/PipelineBuilderBase.cs
@@ -62,7 +62,7 @@ namespace FiftyOne.Pipeline.Core.FlowElements
         /// If true then Pipeline will suppress exceptions added to
         /// <see cref="IFlowData.Errors"/>.
         /// </summary>
-        private bool _suppressProcessExceptions = Constants.PIPELINE_BUILDER_DEFAULT_AUTO_SUPRESS_PROCESS_EXCEPTION;
+        private bool _suppressProcessExceptions = Constants.PIPELINE_BUILDER_DEFAULT_AUTO_SUPRESS_PROCESS_EXCEPTIONS;
 
         private ILogger<Evidence> _evidenceLogger;
         private ILogger<FlowData> _flowDataLogger;
@@ -201,8 +201,29 @@ namespace FiftyOne.Pipeline.Core.FlowElements
         /// <returns>
         /// This builder instance.
         /// </returns>
+#       pragma warning disable CS0618 // Type or member is obsolete
         [DefaultValue(Constants.PIPELINE_BUILDER_DEFAULT_AUTO_SUPRESS_PROCESS_EXCEPTION)]
+#       pragma warning restore CS0618 // Type or member is obsolete
+        [ObsoleteAttribute("This setter is obsolete. Use " + nameof(SetSuppressProcessExceptions) + " instead.", false)]
         public T SetSuppressProcessException(bool suppressExceptions)
+        {
+            return SetSuppressProcessExceptions(suppressExceptions);
+        }
+
+        /// <summary>
+        /// Configure the Pipeline to either suppress exceptions added to
+        /// <see cref="IFlowData.Errors"/> during processing or to throw them
+        /// as an aggregate exception once processing is complete.
+        /// </summary>
+        /// <param name="suppressExceptions">
+        /// If true then Pipeline will suppress exceptions added to
+        /// <see cref="IFlowData.Errors"/>.
+        /// </param>
+        /// <returns>
+        /// This builder instance.
+        /// </returns>
+        [DefaultValue(Constants.PIPELINE_BUILDER_DEFAULT_AUTO_SUPRESS_PROCESS_EXCEPTIONS)]
+        public T SetSuppressProcessExceptions(bool suppressExceptions)
         {
             _suppressProcessExceptions = suppressExceptions;
             return this as T;

--- a/FiftyOne.Pipeline.Engines.TestHelpers/TestPipeline.cs
+++ b/FiftyOne.Pipeline.Engines.TestHelpers/TestPipeline.cs
@@ -48,6 +48,8 @@ namespace FiftyOne.Pipeline.Engines.TestHelpers
 
             public bool IsDisposed => _pipeline.IsDisposed;
 
+            public bool SuppressProcessExceptions => _pipeline.SuppressProcessExceptions;
+
             public IReadOnlyList<IFlowElement> FlowElements => _pipeline.FlowElements;
 
             public IReadOnlyDictionary<string, IReadOnlyDictionary<string, IElementPropertyMetaData>> 

--- a/FiftyOne.Pipeline.Engines/FlowElements/AspectEngineBase.cs
+++ b/FiftyOne.Pipeline.Engines/FlowElements/AspectEngineBase.cs
@@ -84,6 +84,12 @@ namespace FiftyOne.Pipeline.Engines.FlowElements
         }
 
         /// <summary>
+        /// Provide an implementation for the non-generic, 
+        /// aspect-specific version of the meta-data property.
+        /// </summary>
+        public virtual bool HasLoadedProperties { get { return true; } }
+
+        /// <summary>
         /// Constructor
         /// </summary>
         /// <param name="logger">

--- a/FiftyOne.Pipeline.Engines/FlowElements/IAspectEngine.cs
+++ b/FiftyOne.Pipeline.Engines/FlowElements/IAspectEngine.cs
@@ -87,6 +87,12 @@ namespace FiftyOne.Pipeline.Engines.FlowElements
         /// casting, etc.
         /// </summary>
         new IList<IAspectPropertyMetaData> Properties { get; }
+
+        /// <summary>
+        /// Whether `Properties` field already has a meaningful value, 
+        /// or one will be lazily loaded upon next access.
+        /// </summary>
+        bool HasLoadedProperties { get; }
     }
 
     /// <summary>

--- a/FiftyOne.Pipeline.Engines/Services/MissingPropertyService.cs
+++ b/FiftyOne.Pipeline.Engines/Services/MissingPropertyService.cs
@@ -128,24 +128,29 @@ namespace FiftyOne.Pipeline.Engines.Services
             MissingPropertyReason reason = MissingPropertyReason.Unknown;
 
             IAspectPropertyMetaData property = null;
-            property = engine.Properties.FirstOrDefault(p => p.Name == propertyName);
 
-            if (property != null)
+            if (engine.HasLoadedProperties)
             {
-                // Check if the property is available in the data file that is 
-                // being used by the engine.
-                if (property.DataTiersWherePresent.Any(t => t == engine.DataSourceTier) == false)
+                property = engine.Properties.FirstOrDefault(p => p.Name == propertyName);
+
+                if (property != null)
                 {
-                    reason = MissingPropertyReason.DataFileUpgradeRequired;
-                }
-                // Check if the property is excluded from the results.
-                else if (property.Available == false)
-                {
-                    reason = MissingPropertyReason.PropertyExcludedFromEngineConfiguration;
+                    // Check if the property is available in the data file that is 
+                    // being used by the engine.
+                    if (property.DataTiersWherePresent.Any(t => t == engine.DataSourceTier) == false)
+                    {
+                        reason = MissingPropertyReason.DataFileUpgradeRequired;
+                    }
+                    // Check if the property is excluded from the results.
+                    else if (property.Available == false)
+                    {
+                        reason = MissingPropertyReason.PropertyExcludedFromEngineConfiguration;
+                    }
                 }
             }
 
             if(reason == MissingPropertyReason.Unknown &&
+                engine.HasLoadedProperties &&
                 typeof(ICloudAspectEngine).IsAssignableFrom(engine.GetType()))
             {
                 if (engine.Properties.Count == 0)

--- a/FiftyOne.Pipeline.Web.Shared/PipelineWebIntegrationOptions.cs
+++ b/FiftyOne.Pipeline.Web.Shared/PipelineWebIntegrationOptions.cs
@@ -37,6 +37,7 @@ namespace FiftyOne.Pipeline.Web.Shared
             ClientSideEvidenceEnabled = true;
             UseAsyncScript = true;
             UseSetHeaderProperties = true;
+            SuppressProcessExceptionsWeb = false;
         }
 
         /// <summary>
@@ -61,5 +62,12 @@ namespace FiftyOne.Pipeline.Web.Shared
         /// Defaults to true.
         /// </summary>
         public bool UseSetHeaderProperties { get; set; }
+
+        /// <summary>
+        /// Configure the Pipeline to either suppress exceptions added to
+        /// <see cref = "P:FiftyOne.Pipeline.Core.Data.IFlowData.Errors" /> during processing or to throw them
+        /// as an aggregate exception once processing is complete.
+        /// </summary>
+        public bool SuppressProcessExceptionsWeb { get; set; }
     }
 }

--- a/FiftyOne.Pipeline.Web.Shared/PipelineWebIntegrationOptions.cs
+++ b/FiftyOne.Pipeline.Web.Shared/PipelineWebIntegrationOptions.cs
@@ -37,7 +37,6 @@ namespace FiftyOne.Pipeline.Web.Shared
             ClientSideEvidenceEnabled = true;
             UseAsyncScript = true;
             UseSetHeaderProperties = true;
-            SuppressProcessExceptionsWeb = false;
         }
 
         /// <summary>
@@ -62,12 +61,5 @@ namespace FiftyOne.Pipeline.Web.Shared
         /// Defaults to true.
         /// </summary>
         public bool UseSetHeaderProperties { get; set; }
-
-        /// <summary>
-        /// Configure the Pipeline to either suppress exceptions added to
-        /// <see cref = "P:FiftyOne.Pipeline.Core.Data.IFlowData.Errors" /> during processing or to throw them
-        /// as an aggregate exception once processing is complete.
-        /// </summary>
-        public bool SuppressProcessExceptionsWeb { get; set; }
     }
 }

--- a/Tests/FiftyOne.Pipeline.CloudRequestEngine.Tests/CloudRequestEngineBuilderTests.cs
+++ b/Tests/FiftyOne.Pipeline.CloudRequestEngine.Tests/CloudRequestEngineBuilderTests.cs
@@ -121,6 +121,8 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.Tests
                 .SetResourceKey("abcdefgh")
                 .Build();
 
+            _ = cloudRequestsEngine.PublicProperties;
+
             _handlerMock.Protected().Verify(
                "SendAsync",
                Times.Exactly(1), // we expected a single external request
@@ -130,6 +132,8 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.Tests
                ),
                ItExpr.IsAny<CancellationToken>()
             );
+
+            _ = cloudRequestsEngine.EvidenceKeyFilter;
 
             _handlerMock.Protected().Verify(
                "SendAsync",
@@ -158,6 +162,8 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.Tests
                 .SetResourceKey("abcdefgh")
                 .Build();
 
+            _ = cloudRequestsEngine.PublicProperties;
+
             _handlerMock.Protected().Verify(
                "SendAsync",
                Times.Exactly(1), // we expected a single external request
@@ -167,6 +173,8 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.Tests
                ),
                ItExpr.IsAny<CancellationToken>()
             );
+
+            _ = cloudRequestsEngine.EvidenceKeyFilter;
 
             _handlerMock.Protected().Verify(
                "SendAsync",
@@ -191,6 +199,8 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.Tests
                 .SetResourceKey("abcdefgh")
                 .Build();
 
+            _ = cloudRequestsEngine.PublicProperties;
+
             _handlerMock.Protected().Verify(
                "SendAsync",
                Times.Exactly(1), // we expected a single external request
@@ -200,6 +210,8 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.Tests
                ),
                ItExpr.IsAny<CancellationToken>()
             );
+
+            _ = cloudRequestsEngine.EvidenceKeyFilter;
 
             _handlerMock.Protected().Verify(
                "SendAsync",

--- a/Tests/FiftyOne.Pipeline.CloudRequestEngine.Tests/CloudRequestEngineBuilderTests.cs
+++ b/Tests/FiftyOne.Pipeline.CloudRequestEngine.Tests/CloudRequestEngineBuilderTests.cs
@@ -115,17 +115,9 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.Tests
 
             Environment.SetEnvironmentVariable(Constants.FOD_CLOUD_API_URL, "http://localhost/test_env/");
 
-            var cloudRequestsEngine =
-                new CloudRequestEngineBuilder(new LoggerFactory(), new HttpClient(_handlerMock.Object))
-                .SetEndPoint(expectedUrl)
-                .SetResourceKey("abcdefgh")
-                .Build();
-
-            _ = cloudRequestsEngine.PublicProperties;
-
-            _handlerMock.Protected().Verify(
+            Action<int> VerifyPublicPropsTimes = (timesExpected) => _handlerMock.Protected().Verify(
                "SendAsync",
-               Times.Exactly(1), // we expected a single external request
+               Times.Exactly(timesExpected), // we expected a single external request
                ItExpr.Is<HttpRequestMessage>(req =>
                   req.Method == HttpMethod.Get  // we expected a GET request
                   && req.RequestUri.GetLeftPart(UriPartial.Path) == expectedUrl + Constants.PROPERTIES_FILENAME // to this uri
@@ -133,17 +125,45 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.Tests
                ItExpr.IsAny<CancellationToken>()
             );
 
-            _ = cloudRequestsEngine.EvidenceKeyFilter;
-
-            _handlerMock.Protected().Verify(
+            Action<int> VerifyEvidenceKeysTimes = (timesExpected) => _handlerMock.Protected().Verify(
                "SendAsync",
-               Times.Exactly(1), // we expected a single external request
+               Times.Exactly(timesExpected), // we expected a single external request
                ItExpr.Is<HttpRequestMessage>(req =>
                   req.Method == HttpMethod.Get  // we expected a GET request
                   && req.RequestUri.GetLeftPart(UriPartial.Path) == expectedUrl + Constants.EVIDENCE_KEYS_FILENAME // to this uri
                ),
                ItExpr.IsAny<CancellationToken>()
             );
+
+            VerifyPublicPropsTimes(0);
+            VerifyEvidenceKeysTimes(0);
+
+            var cloudRequestsEngine =
+                new CloudRequestEngineBuilder(new LoggerFactory(), new HttpClient(_handlerMock.Object))
+                .SetEndPoint(expectedUrl)
+                .SetResourceKey("abcdefgh")
+                .Build();
+
+            VerifyPublicPropsTimes(0);
+            VerifyEvidenceKeysTimes(0);
+
+            _ = cloudRequestsEngine.PublicProperties;
+
+            VerifyPublicPropsTimes(1);
+            VerifyEvidenceKeysTimes(0);
+
+            _ = cloudRequestsEngine.EvidenceKeyFilter;
+
+            VerifyPublicPropsTimes(1);
+            VerifyEvidenceKeysTimes(1);
+
+            _ = cloudRequestsEngine.PublicProperties;
+            _ = cloudRequestsEngine.PublicProperties;
+            _ = cloudRequestsEngine.EvidenceKeyFilter;
+            _ = cloudRequestsEngine.EvidenceKeyFilter;
+
+            VerifyPublicPropsTimes(1);
+            VerifyEvidenceKeysTimes(1);
         }
 
         /// <summary>
@@ -157,16 +177,9 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.Tests
 
             Environment.SetEnvironmentVariable(Constants.FOD_CLOUD_API_URL, expectedUrl);
 
-            var cloudRequestsEngine =
-                new CloudRequestEngineBuilder(new LoggerFactory(), new HttpClient(_handlerMock.Object))
-                .SetResourceKey("abcdefgh")
-                .Build();
-
-            _ = cloudRequestsEngine.PublicProperties;
-
-            _handlerMock.Protected().Verify(
+            Action<int> VerifyPublicPropsTimes = (timesExpected) => _handlerMock.Protected().Verify(
                "SendAsync",
-               Times.Exactly(1), // we expected a single external request
+               Times.Exactly(timesExpected), // we expected a single external request
                ItExpr.Is<HttpRequestMessage>(req =>
                   req.Method == HttpMethod.Get  // we expected a GET request
                   && req.RequestUri.GetLeftPart(UriPartial.Path) == expectedUrl + Constants.PROPERTIES_FILENAME // to this uri
@@ -174,17 +187,44 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.Tests
                ItExpr.IsAny<CancellationToken>()
             );
 
-            _ = cloudRequestsEngine.EvidenceKeyFilter;
-
-            _handlerMock.Protected().Verify(
+            Action<int> VerifyEvidenceKeysTimes = (timesExpected) => _handlerMock.Protected().Verify(
                "SendAsync",
-               Times.Exactly(1), // we expected a single external request
+               Times.Exactly(timesExpected), // we expected a single external request
                ItExpr.Is<HttpRequestMessage>(req =>
                   req.Method == HttpMethod.Get  // we expected a GET request
                   && req.RequestUri.GetLeftPart(UriPartial.Path) == expectedUrl + Constants.EVIDENCE_KEYS_FILENAME // to this uri
                ),
                ItExpr.IsAny<CancellationToken>()
             );
+
+            VerifyPublicPropsTimes(0);
+            VerifyEvidenceKeysTimes(0);
+
+            var cloudRequestsEngine =
+                new CloudRequestEngineBuilder(new LoggerFactory(), new HttpClient(_handlerMock.Object))
+                .SetResourceKey("abcdefgh")
+                .Build();
+
+            VerifyPublicPropsTimes(0);
+            VerifyEvidenceKeysTimes(0);
+
+            _ = cloudRequestsEngine.PublicProperties;
+
+            VerifyPublicPropsTimes(1);
+            VerifyEvidenceKeysTimes(0);
+
+            _ = cloudRequestsEngine.EvidenceKeyFilter;
+
+            VerifyPublicPropsTimes(1);
+            VerifyEvidenceKeysTimes(1);
+
+            _ = cloudRequestsEngine.PublicProperties;
+            _ = cloudRequestsEngine.PublicProperties;
+            _ = cloudRequestsEngine.EvidenceKeyFilter;
+            _ = cloudRequestsEngine.EvidenceKeyFilter;
+
+            VerifyPublicPropsTimes(1);
+            VerifyEvidenceKeysTimes(1);
         }
 
         /// <summary>
@@ -194,16 +234,9 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.Tests
         [TestMethod]
         public void Endpoint_Config_Precedence_Default()
         {
-            var cloudRequestsEngine =
-                new CloudRequestEngineBuilder(new LoggerFactory(), new HttpClient(_handlerMock.Object))
-                .SetResourceKey("abcdefgh")
-                .Build();
-
-            _ = cloudRequestsEngine.PublicProperties;
-
-            _handlerMock.Protected().Verify(
+            Action<int> VerifyPublicPropsTimes = (timesExpected) => _handlerMock.Protected().Verify(
                "SendAsync",
-               Times.Exactly(1), // we expected a single external request
+               Times.Exactly(timesExpected), // we expected a single external request
                ItExpr.Is<HttpRequestMessage>(req =>
                   req.Method == HttpMethod.Get  // we expected a GET request
                   && req.RequestUri.GetLeftPart(UriPartial.Path) == Constants.PROPERTIES_ENDPOINT_DEFAULT // to this uri
@@ -211,17 +244,44 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.Tests
                ItExpr.IsAny<CancellationToken>()
             );
 
-            _ = cloudRequestsEngine.EvidenceKeyFilter;
-
-            _handlerMock.Protected().Verify(
+            Action<int> VerifyEvidenceKeysTimes = (timesExpected) => _handlerMock.Protected().Verify(
                "SendAsync",
-               Times.Exactly(1), // we expected a single external request
+               Times.Exactly(timesExpected), // we expected a single external request
                ItExpr.Is<HttpRequestMessage>(req =>
                   req.Method == HttpMethod.Get  // we expected a GET request
                   && req.RequestUri.GetLeftPart(UriPartial.Path) == Constants.EVIDENCE_KEYS_ENDPOINT_DEFAULT // to this uri
                ),
                ItExpr.IsAny<CancellationToken>()
             );
+
+            VerifyPublicPropsTimes(0);
+            VerifyEvidenceKeysTimes(0);
+
+            var cloudRequestsEngine =
+                new CloudRequestEngineBuilder(new LoggerFactory(), new HttpClient(_handlerMock.Object))
+                .SetResourceKey("abcdefgh")
+                .Build();
+
+            VerifyPublicPropsTimes(0);
+            VerifyEvidenceKeysTimes(0);
+
+            _ = cloudRequestsEngine.PublicProperties;
+
+            VerifyPublicPropsTimes(1);
+            VerifyEvidenceKeysTimes(0);
+
+            _ = cloudRequestsEngine.EvidenceKeyFilter;
+
+            VerifyPublicPropsTimes(1);
+            VerifyEvidenceKeysTimes(1);
+
+            _ = cloudRequestsEngine.PublicProperties;
+            _ = cloudRequestsEngine.PublicProperties;
+            _ = cloudRequestsEngine.EvidenceKeyFilter;
+            _ = cloudRequestsEngine.EvidenceKeyFilter;
+
+            VerifyPublicPropsTimes(1);
+            VerifyEvidenceKeysTimes(1);
         }
 
         [TestCleanup]

--- a/Tests/FiftyOne.Pipeline.CloudRequestEngine.Tests/CloudRequestEngineTests.cs
+++ b/Tests/FiftyOne.Pipeline.CloudRequestEngine.Tests/CloudRequestEngineTests.cs
@@ -29,6 +29,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Moq.Protected;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Linq;
@@ -49,7 +50,9 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.Tests
         private Uri expectedUri = new Uri("https://cloud.51degrees.com/api/v4/json");
 
         private string _jsonResponse = "{'device':{'value':'1'}}";
+        private HttpStatusCode _jsonResponseStatus = HttpStatusCode.OK;
         private string _evidenceKeysResponse = "['query.User-Agent']";
+        private HttpStatusCode _evidenceKeysResponseStatus = HttpStatusCode.OK;
         private string _accessiblePropertiesResponse =
             "{'Products': {'device': {'DataTier': 'tier','Properties': [{'Name': 'value','Type': 'String','Category': 'Device'}]}}}";
         private HttpStatusCode _accessiblePropertiesResponseStatus = HttpStatusCode.OK;
@@ -566,7 +569,49 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.Tests
                 data.Process();
             }
         }
-        
+
+        /// <summary>
+        /// Test cloud request engine handles a lack of data from the 
+        /// cloud service as expected.
+        /// An exception should be thrown by the cloud request engine
+        /// and the pipeline is configured to throw any exceptions up 
+        /// the stack as an AggregateException.
+        /// </summary>
+        [TestMethod]
+        [ExpectedException(typeof(CloudRequestException))]
+        public void ValidateErrorHandling_NotJson()
+        {
+            string resourceKey = "resource_key";
+
+            _jsonResponse = "Status code: 404, '*json' method not found";
+            _jsonResponseStatus = HttpStatusCode.NotFound;
+
+            _evidenceKeysResponse = "Status code: 404, '*evidencekeys' method not found";
+            _evidenceKeysResponseStatus = HttpStatusCode.NotFound;
+
+            _accessiblePropertiesResponse = "Status code: 404, '*accessibleproperties' method not found";
+            _accessiblePropertiesResponseStatus = HttpStatusCode.NotFound;
+
+            ConfigureMockedClient(_ => true);
+
+            var engine = new CloudRequestEngineBuilder(_loggerFactory, _httpClient)
+                .SetResourceKey(resourceKey)
+                .Build();
+
+            try
+            {
+                var cloudEngineProps = engine.PublicProperties;
+                Assert.Fail("Expected exception did not occur");
+            }
+            catch (CloudRequestException ex)
+            {
+                Assert.AreEqual(ex.HttpStatusCode, 404, "Status code should be 404");
+                Assert.IsNotNull(ex.ResponseHeaders, "Response headers not populated");
+                Assert.IsNotNull(ex.InnerException, "Inner exception not populated");
+                Assert.IsInstanceOfType<JsonReaderException>(ex.InnerException, $"Inner exception is not an instance of {nameof(JsonReaderException)}");
+                throw;
+            }
+        }
         /// <summary>
         /// Verify that the 'DelayExecution' and 'EvidenceProperties'
         /// properties are populated correctly by the CloudRequestEngine.
@@ -885,6 +930,39 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.Tests
         }
 
         /// <summary>
+        /// Verify that an exception throw by the task that is returned by HttpClient.SendAsync
+        /// will be handled and wrapped in nice informative CloudRequestException. 
+        /// </summary>
+        [TestMethod]
+        public void ValidateErrorHandling_ExceptionInRequestTaskSuppressed()
+        {
+            string resourceKey = "resource_key";
+            string userAgent = "iPhone";
+
+            ConfigureMockedClient(r => true, true);
+            var engine = new CloudRequestEngineBuilder(_loggerFactory, _httpClient)
+                .SetResourceKey(resourceKey)
+                .Build();
+
+
+            using (var pipeline = new PipelineBuilder(_loggerFactory).AddFlowElement(engine).SetSuppressProcessExceptions(true).Build())
+            {
+                var data = pipeline.CreateFlowData();
+                data.AddEvidence("query.User-Agent", userAgent);
+                data.Process();
+
+                Assert.IsNotNull(data.Errors);
+                Assert.AreEqual(1, data.Errors.Count);
+                var error = data.Errors[0];
+                Assert.IsInstanceOfType<FlowElements.CloudRequestEngine>(error.FlowElement);
+                var exception = error.ExceptionData;
+
+                Assert.IsNotNull(exception, "Expected exception to occur");
+                Assert.IsInstanceOfType<CloudRequestException>(exception);
+            }
+        }
+
+        /// <summary>
         /// Setup _httpClient to respond with the configured messages.
         /// </summary>
         private void ConfigureMockedClient(
@@ -917,7 +995,7 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.Tests
                // Prepare the expected response of the mocked http call
                setup.ReturnsAsync(new HttpResponseMessage()
                 {
-                    StatusCode = HttpStatusCode.OK,
+                    StatusCode = _jsonResponseStatus,
                     Content = new StringContent(_jsonResponse),
                 })
                .Verifiable();
@@ -936,7 +1014,7 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.Tests
                // prepare the expected response of the mocked http call
                .ReturnsAsync(new HttpResponseMessage()
                {
-                   StatusCode = HttpStatusCode.OK,
+                   StatusCode = _evidenceKeysResponseStatus,
                    Content = new StringContent(_evidenceKeysResponse),
                })
                .Verifiable();

--- a/Tests/FiftyOne.Pipeline.CloudRequestEngine.Tests/CloudRequestEngineTests.cs
+++ b/Tests/FiftyOne.Pipeline.CloudRequestEngine.Tests/CloudRequestEngineTests.cs
@@ -22,6 +22,7 @@
 
 using FiftyOne.Common.TestHelpers;
 using FiftyOne.Pipeline.CloudRequestEngine.FlowElements;
+using FiftyOne.Pipeline.Core.Data;
 using FiftyOne.Pipeline.Core.Exceptions;
 using FiftyOne.Pipeline.Core.FlowElements;
 using Microsoft.Extensions.Logging;
@@ -455,10 +456,13 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.Tests
 
             Exception exception = null;
 
-            try { 
-                var engine = new CloudRequestEngineBuilder(_loggerFactory, _httpClient)
-                    .SetResourceKey(resourceKey)
-                    .Build();
+            var engine = new CloudRequestEngineBuilder(_loggerFactory, _httpClient)
+                .SetResourceKey(resourceKey)
+                .Build();
+
+            try
+            {
+                var cloudEngineProps = engine.PublicProperties;
             }
             catch (Exception ex)
             {
@@ -825,11 +829,13 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.Tests
         {
             string resourceKey = "resource_key";
 
+            var engine = new CloudRequestEngineBuilder(_loggerFactory, new HttpClient())
+                .SetResourceKey(resourceKey)
+                .Build();
+
             try
             {
-                var engine = new CloudRequestEngineBuilder(_loggerFactory, new HttpClient())
-                    .SetResourceKey(resourceKey)
-                    .Build();
+                var cloudEngineProps = engine.PublicProperties;
                 Assert.Fail("Expected exception did not occur");
             }
             catch (CloudRequestException ex)

--- a/Tests/FiftyOne.Pipeline.CloudRequestEngine.Tests/CloudRequestEngineTests.cs
+++ b/Tests/FiftyOne.Pipeline.CloudRequestEngine.Tests/CloudRequestEngineTests.cs
@@ -524,11 +524,13 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.Tests
             }
 
             Assert.IsNotNull(exception, "Expected exception to occur");
-            Assert.IsInstanceOfType(exception, typeof(AggregateException));
-            var aggEx = (exception as AggregateException).Flatten();
+            Assert.IsInstanceOfType<AggregateException>(exception);
+            Assert.IsInstanceOfType<CloudRequestException>(exception.InnerException);
+            Assert.IsInstanceOfType<AggregateException>(exception.InnerException.InnerException);
+            var aggEx = (exception.InnerException.InnerException as AggregateException).Flatten();
             Assert.AreEqual(aggEx.InnerExceptions.Count, 2);
-            Assert.IsInstanceOfType(aggEx.InnerExceptions[0], typeof(PipelineException));
-            Assert.IsInstanceOfType(aggEx.InnerExceptions[1], typeof(PipelineException));
+            Assert.IsInstanceOfType<CloudRequestException>(aggEx.InnerExceptions[0]);
+            Assert.IsInstanceOfType<CloudRequestException>(aggEx.InnerExceptions[1]);
             Assert.IsTrue(aggEx.InnerExceptions.Any(e => e.Message.Contains(
                 "This resource key is not authorized for use with this domain")),
                 "Exception message did not contain the expected text.");

--- a/Tests/FiftyOne.Pipeline.Engines.Tests/Services/MissingPropertyServiceTests.cs
+++ b/Tests/FiftyOne.Pipeline.Engines.Tests/Services/MissingPropertyServiceTests.cs
@@ -52,6 +52,7 @@ namespace FiftyOne.Pipeline.Engines.Tests.Services
             // Arrange
             Mock<IAspectEngine> engine = new Mock<IAspectEngine>();
             engine.Setup(e => e.DataSourceTier).Returns("lite");
+            engine.Setup(e => e.HasLoadedProperties).Returns(true);
             ConfigureProperty(engine);
 
             // Act
@@ -136,6 +137,7 @@ namespace FiftyOne.Pipeline.Engines.Tests.Services
             // Arrange
             Mock<IAspectEngine> engine = new Mock<IAspectEngine>();
             engine.Setup(e => e.DataSourceTier).Returns("premium");
+            engine.Setup(e => e.HasLoadedProperties).Returns(true);
             ConfigureProperty(engine, false);
 
             // Act
@@ -155,6 +157,7 @@ namespace FiftyOne.Pipeline.Engines.Tests.Services
             // Arrange
             Mock<IAspectEngine> engine = new Mock<IAspectEngine>();
             engine.Setup(e => e.DataSourceTier).Returns("premium");
+            engine.Setup(e => e.HasLoadedProperties).Returns(true);
             ConfigureProperty(engine, false);
 
             // Act
@@ -174,6 +177,7 @@ namespace FiftyOne.Pipeline.Engines.Tests.Services
             // Arrange
             Mock<ICloudAspectEngine> engine = new Mock<ICloudAspectEngine>();
             engine.SetupGet(e => e.ElementDataKey).Returns("testElement");
+            engine.SetupGet(e => e.HasLoadedProperties).Returns(true);
             engine.SetupGet(e => e.Properties).Returns(new List<IAspectPropertyMetaData>());
 
             // Act
@@ -206,6 +210,7 @@ namespace FiftyOne.Pipeline.Engines.Tests.Services
             // Arrange
             Mock<ICloudAspectEngine> engine = new Mock<ICloudAspectEngine>();
             engine.SetupGet(e => e.ElementDataKey).Returns("testElement");
+            engine.SetupGet(e => e.HasLoadedProperties).Returns(true);
             ConfigureProperty(engine.As<IAspectEngine>());
 
             // Act
@@ -240,6 +245,7 @@ namespace FiftyOne.Pipeline.Engines.Tests.Services
             // Arrange
             Mock<IAspectEngine> engine = new Mock<IAspectEngine>();
             engine.Setup(e => e.DataSourceTier).Returns("premium");
+            engine.Setup(e => e.HasLoadedProperties).Returns(true);
             ConfigureProperty(engine);
 
             // Act

--- a/Web Integration/FiftyOne.Pipeline.Web.Framework/Providers/PipelineCapabilities.cs
+++ b/Web Integration/FiftyOne.Pipeline.Web.Framework/Providers/PipelineCapabilities.cs
@@ -43,7 +43,8 @@ namespace FiftyOne.Pipeline.Web.Framework.Providers
         public IFlowData FlowData { get; private set; }
         private readonly HttpRequest _request;
         private readonly HttpBrowserCapabilities _baseCaps;
-        
+        private readonly IReadOnlyDictionary<string, IReadOnlyDictionary<string, IElementPropertyMetaData>> _availableElementProperties;
+
         /// <summary>
         /// Constructor
         /// </summary>
@@ -66,6 +67,7 @@ namespace FiftyOne.Pipeline.Web.Framework.Providers
             _baseCaps = baseCaps;
             _request = request;
             FlowData = flowData;
+            _availableElementProperties = FlowData.Pipeline.ElementAvailableProperties;
         }
 
         private string IterateDown(string[] keys, IDictionary<string, object> dict)
@@ -110,13 +112,12 @@ namespace FiftyOne.Pipeline.Web.Framework.Providers
                 // Try getting the value from the FlowData
                 try
                 {
-                    var availableElements = FlowData.Pipeline.ElementAvailableProperties;
                     if (key != null && key.Contains("."))
                     {
                         var keys = key.Split('.');
-                        if (availableElements.ContainsKey(keys[0]) &&
-                            availableElements[keys[0]].ContainsKey(keys[1]) &&
-                            availableElements[keys[0]][keys[1]].Available)
+                        if (_availableElementProperties.ContainsKey(keys[0]) &&
+                            _availableElementProperties[keys[0]].ContainsKey(keys[1]) &&
+                            _availableElementProperties[keys[0]][keys[1]].Available)
                         {
                             var nonStringValue = FlowData.Get(keys[0])[keys[1]];
                             if (nonStringValue as string != null)
@@ -138,14 +139,14 @@ namespace FiftyOne.Pipeline.Web.Framework.Providers
                             }
                         }
                     }
-                    else if (availableElements.Any(i => i.Value.ContainsKey(key)))
+                    else if (_availableElementProperties.Any(i => i.Value.ContainsKey(key)))
                     {
-                        var elementKey = availableElements
+                        var elementKey = _availableElementProperties
                             .First(i => i.Value.ContainsKey(key))
                             .Key;
                         var valueObj = FlowData.Get(elementKey)[key];
 
-                        if (availableElements[elementKey][key].Type.Equals(typeof(IReadOnlyList<string>)))
+                        if (_availableElementProperties[elementKey][key].Type.Equals(typeof(IReadOnlyList<string>)))
                         {
                             value = string.Join("|", ((IEnumerable<object>)valueObj).Select(i => i.ToString()));
                         }
@@ -179,8 +180,8 @@ namespace FiftyOne.Pipeline.Web.Framework.Providers
         {
             get
             {
-                if (FlowData.Pipeline.ElementAvailableProperties.ContainsKey("device") &&
-                    FlowData.Pipeline.ElementAvailableProperties["device"].ContainsKey("ismobile") &&
+                if (_availableElementProperties.ContainsKey("device") &&
+                    _availableElementProperties["device"].ContainsKey("ismobile") &&
                     FlowData.GetAs<AspectPropertyValue<bool>>("ismobile").HasValue)
                 {
                     return FlowData.GetAs<AspectPropertyValue<bool>>("ismobile").Value;
@@ -200,8 +201,8 @@ namespace FiftyOne.Pipeline.Web.Framework.Providers
         {
             get
             {
-                if (FlowData.Pipeline.ElementAvailableProperties.ContainsKey("device") &&
-                    FlowData.Pipeline.ElementAvailableProperties["device"].ContainsKey("supportsphonecalls") &&
+                if (_availableElementProperties.ContainsKey("device") &&
+                    _availableElementProperties["device"].ContainsKey("supportsphonecalls") &&
                     FlowData.GetAs<AspectPropertyValue<bool>>("supportsphonecalls").HasValue)
                 {
                     return FlowData.GetAs<AspectPropertyValue<bool>>("supportsphonecalls").Value;
@@ -220,8 +221,8 @@ namespace FiftyOne.Pipeline.Web.Framework.Providers
         {
             get
             {
-                if (FlowData.Pipeline.ElementAvailableProperties.ContainsKey("device") &&
-                    FlowData.Pipeline.ElementAvailableProperties["device"].ContainsKey("oem") &&
+                if (_availableElementProperties.ContainsKey("device") &&
+                    _availableElementProperties["device"].ContainsKey("oem") &&
                     FlowData.GetAs<AspectPropertyValue<string>>("oem").HasValue)
                 {
                     return FlowData.GetAs<AspectPropertyValue<string>>("oem").Value;
@@ -240,8 +241,8 @@ namespace FiftyOne.Pipeline.Web.Framework.Providers
         {
             get
             {
-                if (FlowData.Pipeline.ElementAvailableProperties.ContainsKey("device") &&
-                    FlowData.Pipeline.ElementAvailableProperties["device"].ContainsKey("hardwaremodel") &&
+                if (_availableElementProperties.ContainsKey("device") &&
+                    _availableElementProperties["device"].ContainsKey("hardwaremodel") &&
                     FlowData.GetAs<AspectPropertyValue<string>>("hardwaremodel").HasValue)
                 {
                     return FlowData.GetAs<AspectPropertyValue<string>>("hardwaremodel").Value;
@@ -260,8 +261,8 @@ namespace FiftyOne.Pipeline.Web.Framework.Providers
         public override int ScreenPixelsHeight {
             get
             {
-                if (FlowData.Pipeline.ElementAvailableProperties.ContainsKey("device") &&
-                    FlowData.Pipeline.ElementAvailableProperties["device"].ContainsKey("screenpixelsheight") &&
+                if (_availableElementProperties.ContainsKey("device") &&
+                    _availableElementProperties["device"].ContainsKey("screenpixelsheight") &&
                     FlowData.GetAs<AspectPropertyValue<int>>("screenpixelsheight").HasValue)
                 {
                     return FlowData.GetAs<AspectPropertyValue<int>>("screenpixelsheight").Value;
@@ -281,8 +282,8 @@ namespace FiftyOne.Pipeline.Web.Framework.Providers
         {
             get
             {
-                if (FlowData.Pipeline.ElementAvailableProperties.ContainsKey("device") &&
-                    FlowData.Pipeline.ElementAvailableProperties["device"].ContainsKey("screenpixelswidth") &&
+                if (_availableElementProperties.ContainsKey("device") &&
+                    _availableElementProperties["device"].ContainsKey("screenpixelswidth") &&
                     FlowData.GetAs<AspectPropertyValue<int>>("screenpixelswidth").HasValue)
                 {
                     return FlowData.GetAs<AspectPropertyValue<int>>("screenpixelswidth").Value;

--- a/Web Integration/FiftyOne.Pipeline.Web.Framework/WebPipeline.cs
+++ b/Web Integration/FiftyOne.Pipeline.Web.Framework/WebPipeline.cs
@@ -283,7 +283,7 @@ namespace FiftyOne.Pipeline.Web.Framework
 
                 AddRequestProtocolToEvidence(flowData, request);
             } 
-            catch (Exception ex) when (ex is IFlowError)
+            catch (Exception ex)
             {
                 if (!GetInstance().SuppressProcessExceptionsWeb)
                 {
@@ -304,7 +304,7 @@ namespace FiftyOne.Pipeline.Web.Framework
                     SetHeadersProvider.GetInstance().SetHeaders(flowData,
                         request.RequestContext.HttpContext.ApplicationInstance.Context);
                 }
-                catch (Exception ex) when (ex is IFlowError)
+                catch (Exception ex)
                 {
                     if (!GetInstance().SuppressProcessExceptionsWeb)
                     {

--- a/Web Integration/FiftyOne.Pipeline.Web.Framework/WebPipeline.cs
+++ b/Web Integration/FiftyOne.Pipeline.Web.Framework/WebPipeline.cs
@@ -318,7 +318,7 @@ namespace FiftyOne.Pipeline.Web.Framework
         /// A convenience wrapper around IFlowData.
         /// Reduces amount of calls to `IFlowData.EvidenceKeyFilter`
         /// </summary>
-        private struct EvidenceFiller
+        public struct EvidenceFiller
         {
             private readonly IFlowData _flowData;
             private readonly IEvidenceKeyFilter _evidenceKeyFilter;

--- a/Web Integration/FiftyOne.Pipeline.Web.Framework/WebPipeline.cs
+++ b/Web Integration/FiftyOne.Pipeline.Web.Framework/WebPipeline.cs
@@ -34,13 +34,10 @@ using FiftyOne.Pipeline.Web.Framework.Providers;
 using FiftyOne.Pipeline.Web.Shared;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
-using NUglify.JavaScript.Syntax;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Web;
-using System.Xml.Linq;
 
 namespace FiftyOne.Pipeline.Web.Framework
 {

--- a/Web Integration/FiftyOne.Pipeline.Web.Framework/WebPipeline.cs
+++ b/Web Integration/FiftyOne.Pipeline.Web.Framework/WebPipeline.cs
@@ -64,13 +64,6 @@ namespace FiftyOne.Pipeline.Web.Framework
         public bool SetHeaderPropertiesEnabled => _options.UseSetHeaderProperties;
 
         /// <summary>
-        /// Configure the Pipeline to either suppress exceptions added to
-        /// <see cref = "P:FiftyOne.Pipeline.Core.Data.IFlowData.Errors" /> during processing or to throw them
-        /// as an aggregate exception once processing is complete.
-        /// </summary>
-        public bool SuppressProcessExceptionsWeb => _options.SuppressProcessExceptionsWeb;
-
-        /// <summary>
         /// Extra pipeline options which only apply to an implementation in a
         /// web server.
         /// </summary>
@@ -285,7 +278,7 @@ namespace FiftyOne.Pipeline.Web.Framework
             } 
             catch (Exception ex)
             {
-                if (!GetInstance().SuppressProcessExceptionsWeb)
+                if (!GetInstance().Pipeline.SuppressProcessExceptions)
                 {
                     throw;
                 }
@@ -306,7 +299,7 @@ namespace FiftyOne.Pipeline.Web.Framework
                 }
                 catch (Exception ex)
                 {
-                    if (!GetInstance().SuppressProcessExceptionsWeb)
+                    if (!GetInstance().Pipeline.SuppressProcessExceptions)
                     {
                         throw;
                     }
@@ -322,7 +315,7 @@ namespace FiftyOne.Pipeline.Web.Framework
             // suppressed, then throw an aggregate exception.
             if (webErrors != null && webErrors.Count > 0)
             {
-                if (GetInstance().SuppressProcessExceptionsWeb)
+                if (GetInstance().Pipeline.SuppressProcessExceptions)
                 {
                     foreach (Exception ex in webErrors)
                     {

--- a/Web Integration/FiftyOne.Pipeline.Web.Framework/WebPipeline.cs
+++ b/Web Integration/FiftyOne.Pipeline.Web.Framework/WebPipeline.cs
@@ -225,6 +225,10 @@ namespace FiftyOne.Pipeline.Web.Framework
         /// <exception cref="ArgumentNullException">
         /// Thrown if a required parameter is null.
         /// </exception>
+        /// <exception cref="AggregateException">
+        /// Thrown if an error occurred during processing, 
+        /// unless inderlying <see ref="IPipeline.SuppressProcessExceptions"/> is true.
+        /// </exception>
         public static IFlowData Process(HttpRequest request)
         {
             if (request == null) throw new ArgumentNullException(nameof(request));
@@ -315,14 +319,11 @@ namespace FiftyOne.Pipeline.Web.Framework
             // suppressed, then throw an aggregate exception.
             if (webErrors != null && webErrors.Count > 0)
             {
-                if (GetInstance().Pipeline.SuppressProcessExceptions)
+                foreach (Exception ex in webErrors)
                 {
-                    foreach (Exception ex in webErrors)
-                    {
-                        flowData.AddError(ex, null);
-                    }
+                    flowData.AddError(ex, null);
                 }
-                else
+                if (!GetInstance().Pipeline.SuppressProcessExceptions)
                 {
                     throw new AggregateException(webErrors);
                 }

--- a/Web Integration/FiftyOne.Pipeline.Web.Framework/WebPipeline.cs
+++ b/Web Integration/FiftyOne.Pipeline.Web.Framework/WebPipeline.cs
@@ -333,12 +333,17 @@ namespace FiftyOne.Pipeline.Web.Framework
             /// The <see cref="IFlowData"/> to add the evidence to.
             /// </param>
             /// <exception cref="PipelineException">
-            /// may be rethrown from <see cref="IFlowData.EvidenceKeyFilter"/>
+            /// thrown if <see cref="IFlowData.EvidenceKeyFilter"/> is null
+            /// or re-thrown from <see cref="IFlowData.EvidenceKeyFilter"/> itself
             /// </exception>
             public EvidenceFiller(IFlowData flowData)
             {
                 _flowData = flowData;
                 _evidenceKeyFilter = flowData.EvidenceKeyFilter;
+                if (_evidenceKeyFilter is null)
+                {
+                    throw new PipelineException($"Failed to retrieve {nameof(flowData.EvidenceKeyFilter)} from {nameof(flowData)}");
+                }
                 _errors = null;
             }
 

--- a/Web Integration/Tests/FiftyOne.Pipeline.Web.Framework.Tests/FiftyOne.Pipeline.Web.Framework.Tests.csproj
+++ b/Web Integration/Tests/FiftyOne.Pipeline.Web.Framework.Tests/FiftyOne.Pipeline.Web.Framework.Tests.csproj
@@ -50,6 +50,7 @@
   <ItemGroup>
     <Compile Include="Dependencies.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="WebPipelineEvidenceFillerTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\FiftyOne.Pipeline.Core\FiftyOne.Pipeline.Core.csproj">
@@ -83,6 +84,9 @@
     </PackageReference>
     <PackageReference Include="MSTest.TestFramework">
       <Version>3.1.1</Version>
+    </PackageReference>
+    <PackageReference Include="NSubstitute">
+      <Version>5.0.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Web Integration/Tests/FiftyOne.Pipeline.Web.Framework.Tests/WebPipelineEvidenceFillerTests.cs
+++ b/Web Integration/Tests/FiftyOne.Pipeline.Web.Framework.Tests/WebPipelineEvidenceFillerTests.cs
@@ -1,0 +1,24 @@
+﻿using FiftyOne.Pipeline.Core.Data;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+using System;
+
+namespace FiftyOne.Pipeline.Web.Framework.Tests
+{
+    [TestClass]
+    public class WebPipelineEvidenceFillerTests
+    {
+        [TestMethod]
+        public void TestConstructor()
+        {
+            var filter = Substitute.For<IEvidenceKeyFilter>();
+            var fakeData = Substitute.For<IFlowData>();
+            fakeData.EvidenceKeyFilter.Returns(filter);
+            
+            var filler = new WebPipeline.EvidenceFiller(fakeData);
+
+            _ = fakeData.Received(1).EvidenceKeyFilter;
+            Assert.IsNull(filler.Errors);
+        }
+    }
+}

--- a/Web Integration/Tests/FiftyOne.Pipeline.Web.Framework.Tests/WebPipelineEvidenceFillerTests.cs
+++ b/Web Integration/Tests/FiftyOne.Pipeline.Web.Framework.Tests/WebPipelineEvidenceFillerTests.cs
@@ -2,14 +2,24 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
 using System;
+using System.Collections.Generic;
+using System.Net.Configuration;
 
 namespace FiftyOne.Pipeline.Web.Framework.Tests
 {
     [TestClass]
     public class WebPipelineEvidenceFillerTests
     {
+        private class FakeException : Exception
+        {
+            public FakeException(): base() { }
+            public FakeException(string msg) : base(msg) { }
+            public FakeException(string msg, Exception ex) : base(msg, ex) { }
+        }
+
+
         [TestMethod]
-        public void TestConstructor()
+        public void TestConstructor_Ok()
         {
             var filter = Substitute.For<IEvidenceKeyFilter>();
             var fakeData = Substitute.For<IFlowData>();
@@ -19,6 +29,76 @@ namespace FiftyOne.Pipeline.Web.Framework.Tests
 
             _ = fakeData.Received(1).EvidenceKeyFilter;
             Assert.IsNull(filler.Errors);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(NullReferenceException))] // pass through (not explicitly handled)
+        public void TestConstructor_NoData()
+        {
+            var filler = new WebPipeline.EvidenceFiller(null);
+        }
+
+        [TestMethod]
+        public void TestConstructor_NullFilter() // ignored till later
+        {
+            IEvidenceKeyFilter noFilter = null;
+            var fakeData = Substitute.For<IFlowData>();
+            fakeData.EvidenceKeyFilter.Returns(noFilter);
+
+            var filler = new WebPipeline.EvidenceFiller(fakeData);
+
+            _ = fakeData.Received(1).EvidenceKeyFilter;
+            Assert.IsNull(filler.Errors);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(FakeException))]
+        public void TestConstructor_ErrorOnFilter()
+        {
+            var fakeData = Substitute.For<IFlowData>();
+            fakeData.EvidenceKeyFilter.Returns(x => { throw new FakeException("no filter"); });
+
+            var filler = new WebPipeline.EvidenceFiller(fakeData);
+        }
+
+        [TestMethod]
+        public void TestCheckToAdd_Normal()
+        {
+            var fakeData = Substitute.For<IFlowData>();
+
+            var filter = Substitute.For<IEvidenceKeyFilter>();
+            filter.Include(Arg.Any<string>()).Returns(x => ((string)x[0]).Contains("s"));
+            fakeData.EvidenceKeyFilter.Returns(filter);
+
+            var savedData = new Dictionary<string, object>();
+            fakeData
+                .When(x => x.AddEvidence(Arg.Any<string>(), Arg.Any<object>()))
+                .Do(x => savedData[(string)x[0]] = x[1]);
+
+            var testData = new Dictionary<string, string>()
+            {
+                { "crabby", "crabs" },
+                { "sleepy", "beetle" },
+                { "zummy", "fish" },
+                { "gloomy", "day" },
+                { "fishy", "cat" },
+                { "raw", "beef" },
+            };
+
+
+            var filler = new WebPipeline.EvidenceFiller(fakeData);
+            foreach ( var data in testData )
+            {
+                filler.CheckAndAdd(data.Key, data.Value);
+            }
+
+            _ = fakeData.Received(1).EvidenceKeyFilter;
+            Assert.IsNull(filler.Errors);
+            CollectionAssert.AreEquivalent(new Dictionary<string, object>()
+            {
+                { "sleepy", "beetle" },
+                { "fishy", "cat" },
+            }, savedData);
         }
     }
 }

--- a/Web Integration/Tests/FiftyOne.Pipeline.Web.Framework.Tests/WebPipelineEvidenceFillerTests.cs
+++ b/Web Integration/Tests/FiftyOne.Pipeline.Web.Framework.Tests/WebPipelineEvidenceFillerTests.cs
@@ -1,4 +1,5 @@
 ﻿using FiftyOne.Pipeline.Core.Data;
+using FiftyOne.Pipeline.Core.Exceptions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
 using NSubstitute.ReceivedExtensions;
@@ -35,27 +36,25 @@ namespace FiftyOne.Pipeline.Web.Framework.Tests
 
         [TestMethod]
         [ExpectedException(typeof(NullReferenceException))] // pass through (not explicitly handled)
-        public void TestConstructor_NoData()
+        public void TestConstructor_Error_OnNullData()
         {
             var filler = new WebPipeline.EvidenceFiller(null);
         }
 
         [TestMethod]
-        public void TestConstructor_NullFilter() // ignored till later
+        [ExpectedException(typeof(PipelineException))]
+        public void TestConstructor_Error_OnNullFilter()
         {
             IEvidenceKeyFilter noFilter = null;
             var fakeData = Substitute.For<IFlowData>();
             fakeData.EvidenceKeyFilter.Returns(noFilter);
 
             var filler = new WebPipeline.EvidenceFiller(fakeData);
-
-            _ = fakeData.Received(1).EvidenceKeyFilter;
-            Assert.IsNull(filler.Errors);
         }
 
         [TestMethod]
         [ExpectedException(typeof(FakeException))]
-        public void TestConstructor_ErrorOnFilter()
+        public void TestConstructor_Error_OnGetFilter()
         {
             var fakeData = Substitute.For<IFlowData>();
             fakeData.EvidenceKeyFilter.Returns(x => { throw new FakeException("no filter"); });
@@ -64,7 +63,7 @@ namespace FiftyOne.Pipeline.Web.Framework.Tests
         }
 
         [TestMethod]
-        public void TestCheckToAdd_Normal()
+        public void TestCheckToAdd_Ok()
         {
             var fakeData = Substitute.For<IFlowData>();
 
@@ -98,7 +97,7 @@ namespace FiftyOne.Pipeline.Web.Framework.Tests
         }
 
         [TestMethod]
-        public void TestCheckToAdd_ArgumentNull_OnAddEvidence()
+        public void TestCheckToAdd_Error_OnAddEvidence()
         {
             var fakeData = Substitute.For<IFlowData>();
 
@@ -146,7 +145,7 @@ namespace FiftyOne.Pipeline.Web.Framework.Tests
         }
 
         [TestMethod]
-        public void TestCheckToAdd_ArgumentNull_OnInclude()
+        public void TestCheckToAdd_Error_OnInclude()
         {
             var fakeData = Substitute.For<IFlowData>();
 


### PR DESCRIPTION
#### Context

See https://github.com/51Degrees/pipeline-dotnet/issues/44

#### Changes

- Call `GetCloudEvidenceKeys` / `GetCloudProperties` from respective `CloudRequestEngine`'s property getters, instead of early assignment (in constructor).
- Add new `HasLoadedProperties` property on `IAspectEngine` interface for `MissingPropertyService` not to re-invoke `CloudRequestEngine.GetCloudProperties` when no response is available yet.
- Duplicate and deprecate `PipelineBuilderBase.SetSuppressProcessException` and `Constants.PIPELINE_BUILDER_DEFAULT_AUTO_SUPRESS_PROCESS_EXCEPTION` in favour of ones ending with an `s` --- to align with a spelling from [specification docs](https://github.com/51Degrees/specifications/blob/main/pipeline-specification/features/exception-handling.md?plain=1#L40).
- Make `CloudRequestEngine.Process` catch `JsonReaderException` and wrap into `CloudRequestException` before re-throwing.
- Adjust the way `CloudRequestEngine.Process` reports multiple `responseJson.errors` --- wrap `AggregateException` into `CloudRequestException` before throwing --- as the former does not derive from `PipelineException`.
- Add new `CloudRequestException` constructor with all 4 available arguments.
- Expose `SuppressProcessExceptions` property on `IPipeline`.
- Make `WebPipeline.Process` respect `SuppressProcessExceptions` flag of underlying `IPipeline`.
- Introduce `WebPipeline.EvidenceFiller` struct as a means to: cache (in scope of `WebPipeline.Process` call) `IFlowData.EvidenceKeyFilter`, improve the readability of `WebPipeline.Process` (by reducing `foreach` loops clutter) and isolate failures (occurring when adding specific evidence pieces) to add as much evidence as possible before reporting/re-throwing all occurred errors.
- Introduce `PropertiesNotYetLoadedException` for `IFlowElement.Properties` to signal about _temporary_ unavailability of properties.
- Update `CloudAspectEngineBase.Properties` to wrap underlying `CloudRequestException` (by `CloudRequestEngine.PublicProperties`) into `PropertiesNotYetLoadedException`.
- Save the result of `Pipeline.GetElementAvailableProperties` to `_elementAvailableProperties` only once no element throws `PropertiesNotYetLoadedException` from its `IFlowElement.Properties` during enumeration.
- Save `FlowData.Pipeline.ElementAvailableProperties` value in `PipelineCapabilities` constructor and reuse later to prevent multiple failed connections to cloud server.
- Update some documentation comments.
- Fix and add tests.
