### PR TITLE
Fix missing runtime assembly for `FiftyOne.Pipeline.Web.Framework.Tests.Dependencies`

### DIFF
--- a/Tests/FiftyOne.Pipeline.Engines.Tests/Services/DataUpdateServiceTests.cs
+++ b/Tests/FiftyOne.Pipeline.Engines.Tests/Services/DataUpdateServiceTests.cs
@@ -663,6 +663,7 @@ namespace FiftyOne.Pipeline.Engines.Tests.Services
             Mock<IOnPremiseAspectEngine> engine = new Mock<IOnPremiseAspectEngine>();
             string tempPath = Path.GetTempPath();
             string dataFile = Path.GetTempFileName();
+            if (File.Exists(dataFile)) { File.Delete(dataFile); }
             try
             {
                 // Configure the engine to return the relevant paths.
@@ -847,6 +848,7 @@ namespace FiftyOne.Pipeline.Engines.Tests.Services
             Mock<IOnPremiseAspectEngine> engine = new Mock<IOnPremiseAspectEngine>();
             string tempPath = Path.GetTempPath();
             string dataFile = Path.GetTempFileName();
+            if (File.Exists(dataFile)) { File.Delete(dataFile); }
             try
             {
                 // Configure the engine to return the relevant paths.

--- a/Web Integration/Tests/FiftyOne.Pipeline.Web.Framework.Tests/FiftyOne.Pipeline.Web.Framework.Tests.csproj
+++ b/Web Integration/Tests/FiftyOne.Pipeline.Web.Framework.Tests/FiftyOne.Pipeline.Web.Framework.Tests.csproj
@@ -41,7 +41,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Web Integration/Tests/FiftyOne.Pipeline.Web.Framework.Tests/FiftyOne.Pipeline.Web.Framework.Tests.csproj
+++ b/Web Integration/Tests/FiftyOne.Pipeline.Web.Framework.Tests/FiftyOne.Pipeline.Web.Framework.Tests.csproj
@@ -41,7 +41,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup>
-    <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Web Integration/Tests/FiftyOne.Pipeline.Web.Framework.Tests/app.config
+++ b/Web Integration/Tests/FiftyOne.Pipeline.Web.Framework.Tests/app.config
@@ -6,6 +6,10 @@
         <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.4" newVersion="6.0.0.4"/>
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/Web Integration/Tests/FiftyOne.Pipeline.Web.Framework.Tests/app.config
+++ b/Web Integration/Tests/FiftyOne.Pipeline.Web.Framework.Tests/app.config
@@ -7,7 +7,7 @@
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.4" newVersion="6.0.0.4"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
       </dependentAssembly>
     </assemblyBinding>


### PR DESCRIPTION
#### Motivation

Assembly not found during both [CI action](https://github.com/51Degrees/pipeline-dotnet/runs/16737849869) and locally (VS 2022 on Windows 11) :
<img width="765" alt="Screenshot 2023-09-13 115530" src="https://github.com/51Degrees/pipeline-dotnet/assets/5711520/2b8d3186-77fb-4b78-ad1d-4e402caac6d0">

#### Changes

- Redirect `System.Runtime.CompilerServices.Unsafe` assembly reference to `6.0.0.0` in `app.config`
- Add local file cleanup _before_ running the logic (in addition to _after_) in a couple of test cases.

#### Effect

Test passes locally (VS 2022 on Windows 11) :
<img width="767" alt="Screenshot 2023-09-13 115509" src="https://github.com/51Degrees/pipeline-dotnet/assets/5711520/a5300734-855a-427a-9fb5-b2e044ce803f">
