### PR TITLE
Failed DataUpdateService_UpdateFromUrl_HttpException

### DIFF
--- a/Tests/FiftyOne.Pipeline.Engines.Tests/Services/DataUpdateServiceTests.cs
+++ b/Tests/FiftyOne.Pipeline.Engines.Tests/Services/DataUpdateServiceTests.cs
@@ -102,8 +102,18 @@ namespace FiftyOne.Pipeline.Engines.Tests.Services
         [TestCleanup]
         public void Cleanup()
         {
-            _logger.AssertMaxErrors(_ignoreErrors);
-            _logger.AssertMaxWarnings(_ignoreWranings);
+            try
+            {
+                _logger.AssertMaxErrors(_ignoreErrors);
+                _logger.AssertMaxWarnings(_ignoreWranings);
+            }
+            finally
+            {
+                foreach (var entry in _logger.Entries)
+                {
+                    Console.WriteLine($"[LOGGER LOGS] {entry.Key} > {entry.Value}");
+                }
+            }
         }
 
         /// <summary>

--- a/Tests/FiftyOne.Pipeline.Engines.Tests/Services/DataUpdateServiceTests.cs
+++ b/Tests/FiftyOne.Pipeline.Engines.Tests/Services/DataUpdateServiceTests.cs
@@ -53,6 +53,7 @@ namespace FiftyOne.Pipeline.Engines.Tests.Services
         private int _ignoreWranings = 0;
         private int _ignoreErrors = 0;
         private const int TEST_TIMEOUT_MS = 3000;
+        private const int LOGGING_TIMEOUT_MS = 75;
 
         private DataUpdateService _dataUpdate;
 
@@ -890,6 +891,7 @@ namespace FiftyOne.Pipeline.Engines.Tests.Services
                 // Assert
                 Assert.IsTrue(completeFlag.IsSet, "The 'CheckForUpdateComplete' " +
                     "event was never fired");
+                Thread.Sleep(LOGGING_TIMEOUT_MS);
                 _httpHandler.Verify(h => h.Send(It.IsAny<HttpRequestMessage>()), Times.Once());
                 // Make sure engine was not refreshed
                 engine.Verify(e => e.RefreshData(config.Identifier), Times.Never());


### PR DESCRIPTION
### Issue:

- https://github.com/51Degrees/pipeline-dotnet/actions/runs/6256335015/job/16987011987#step:5:385

### Attempted solution:

- Add `sleep` before checking logger's contents.

### Other changes:

- Dump logs from `_logger` into test output during `Cleanup`