### PR TITLE
Lazify clientside property service headers

### DIFF
--- a/.github/workflows/monthly-copyright-update.yml
+++ b/.github/workflows/monthly-copyright-update.yml
@@ -12,5 +12,6 @@ jobs:
     uses: 51Degrees/common-ci/.github/workflows/monthly-copyright-update.yml@main
     with:
       repo-name: ${{ github.event.repository.name }}
+      org-name: ${{ github.event.repository.owner.login }}
     secrets:
       token: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/nightly-documentation-update.yml
+++ b/.github/workflows/nightly-documentation-update.yml
@@ -13,5 +13,6 @@ jobs:
     uses: 51Degrees/common-ci/.github/workflows/nightly-documentation-update.yml@main
     with:
       repo-name: ${{ github.event.repository.name }}
+      org-name: ${{ github.event.repository.owner.login }}
     secrets:
       token: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/nightly-package-update.yml
+++ b/.github/workflows/nightly-package-update.yml
@@ -11,5 +11,6 @@ jobs:
     uses: 51Degrees/common-ci/.github/workflows/nightly-package-update.yml@main
     with:
       repo-name: ${{ github.event.repository.name }}
+      org-name: ${{ github.event.repository.owner.login }}
     secrets:
       token: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/nightly-prs-to-main.yml
+++ b/.github/workflows/nightly-prs-to-main.yml
@@ -12,5 +12,6 @@ jobs:
     uses: 51Degrees/common-ci/.github/workflows/nightly-prs-to-main.yml@main
     with:
       repo-name: ${{ github.event.repository.name }}
+      org-name: ${{ github.event.repository.owner.login }}
     secrets:
       token: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/nightly-publish-main.yml
+++ b/.github/workflows/nightly-publish-main.yml
@@ -12,6 +12,7 @@ jobs:
     uses: 51Degrees/common-ci/.github/workflows/nightly-publish-main.yml@main
     with:
       repo-name: ${{ github.event.repository.name }}
+      org-name: ${{ github.event.repository.owner.login }}
       build-platform: windows-latest
     secrets:
       token: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/nightly-submodule-update.yml
+++ b/.github/workflows/nightly-submodule-update.yml
@@ -12,5 +12,6 @@ jobs:
     uses: 51Degrees/common-ci/.github/workflows/nightly-submodule-update.yml@main
     with:
       repo-name: ${{ github.event.repository.name }}
+      org-name: ${{ github.event.repository.owner.login }}
     secrets:
       token: ${{ secrets.ACCESS_TOKEN }}

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElement/FlowElement/JavaScriptBuilderElement.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElement/FlowElement/JavaScriptBuilderElement.cs
@@ -245,12 +245,27 @@ namespace FiftyOne.Pipeline.JavaScriptBuilder.FlowElement
         /// </exception>
         protected override void ProcessInternal(IFlowData data)
         {
-            if (data == null) throw new ArgumentNullException(nameof(data));
-            SetUp(data);
+            SetUp(data, GetOrAddToData(data));
         }
 
-        private void SetUp(IFlowData data)
+
+        /// <summary>
+        /// Default process method.
+        /// </summary>
+        /// <param name="data"></param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if the supplied flow data is null.
+        /// </exception>
+        public JavaScriptBuilderElementData GetFallbackResponse(IFlowData data)
         {
+            JavaScriptBuilderElementData result = (JavaScriptBuilderElementData)CreateElementData(data.Pipeline);
+            SetUp(data, () => result);
+            return result;
+        }
+
+        private void SetUp(IFlowData data, Func<JavaScriptBuilderElementData> targetElementDataProvider)
+        {
+            if (data == null) throw new ArgumentNullException(nameof(data));
             var host = Host;
             var protocol = Protocol;
             bool supportsPromises = false;
@@ -380,7 +395,7 @@ namespace FiftyOne.Pipeline.JavaScriptBuilder.FlowElement
             }
 
             // With the gathered resources, build a new JavaScriptResource.
-            BuildJavaScript(data, jsonObject, sessionId, sequence, supportsPromises, supportsFetch, url, paramsObject);
+            BuildJavaScript(data, targetElementDataProvider, jsonObject, sessionId, sequence, supportsPromises, supportsFetch, url, paramsObject);
         }
 
 
@@ -474,6 +489,12 @@ namespace FiftyOne.Pipeline.JavaScriptBuilder.FlowElement
         /// <param name="data">
         /// The <see cref="IFlowData"/> instance to populate with the
         /// resulting <see cref="JavaScriptBuilderElementData"/> 
+        /// and additional evidence source
+        /// </param>
+        /// <param name="targetElementDataProvider">
+        /// The method the will inject the resulting 
+        /// <see cref="JavaScriptBuilderElementData"/> 
+        /// into the response (even if differs from `data` above)
         /// </param>
         /// <param name="jsonObject">
         /// The JSON data object to include in the JavaScript.
@@ -503,6 +524,7 @@ namespace FiftyOne.Pipeline.JavaScriptBuilder.FlowElement
         /// </exception>
         protected void BuildJavaScript(
             IFlowData data,
+            Func<JavaScriptBuilderElementData> targetElementDataProvider,
             string jsonObject,
             string sessionId,
             int sequence,
@@ -511,7 +533,15 @@ namespace FiftyOne.Pipeline.JavaScriptBuilder.FlowElement
             string url,
             string parameters)
         {
-            BuildJavaScript(data, jsonObject, sessionId, sequence, supportsPromises, supportsFetch, new Uri(url), parameters);
+            BuildJavaScript(data, targetElementDataProvider, jsonObject, sessionId, sequence, supportsPromises, supportsFetch, new Uri(url), parameters);
+        }
+
+        private Func<JavaScriptBuilderElementData> GetOrAddToData(IFlowData data)
+        {
+            return () => (JavaScriptBuilderElementData)
+                data.GetOrAdd(
+                ElementDataKeyTyped,
+                CreateElementData);
         }
 
         /// <summary>
@@ -521,6 +551,12 @@ namespace FiftyOne.Pipeline.JavaScriptBuilder.FlowElement
         /// <param name="data">
         /// The <see cref="IFlowData"/> instance to populate with the
         /// resulting <see cref="JavaScriptBuilderElementData"/> 
+        /// and additional evidence source
+        /// </param>
+        /// <param name="targetElementDataProvider">
+        /// The method the will inject the resulting 
+        /// <see cref="JavaScriptBuilderElementData"/> 
+        /// into the response (even if differs from `data` above)
         /// </param>
         /// <param name="jsonObject">
         /// The JSON data object to include in the JavaScript.
@@ -549,7 +585,8 @@ namespace FiftyOne.Pipeline.JavaScriptBuilder.FlowElement
         /// Thrown if the supplied flow data is null.
         /// </exception>
         protected void BuildJavaScript(
-            IFlowData data,
+            IFlowData data, 
+            Func<JavaScriptBuilderElementData> targetElementDataProvider,
             string jsonObject,
             string sessionId,
             int sequence,
@@ -559,11 +596,8 @@ namespace FiftyOne.Pipeline.JavaScriptBuilder.FlowElement
             string parameters)
         {
             if (data == null) throw new ArgumentNullException(nameof(data));
-            
-            JavaScriptBuilderElementData elementData = (JavaScriptBuilderElementData)
-                data.GetOrAdd(
-                ElementDataKeyTyped,
-                CreateElementData);
+
+            JavaScriptBuilderElementData elementData = targetElementDataProvider();
 
             string objectName = ObjName;
             // Try and get the requested object name from evidence.

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/JavaScriptBuilderElementTests.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/JavaScriptBuilderElementTests.cs
@@ -199,6 +199,34 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
         /// <summary>
         /// Check that the callback URL is generated correctly.
         /// </summary>
+        [TestMethod]
+        public void JavaScriptBuilder_VerifyFallbackResponse()
+        {
+            _javaScriptBuilderElement =
+                new JavaScriptBuilderElementBuilder(_loggerFactory)
+                .SetEndpoint("/json")
+                .Build();
+
+            var flowData = new Mock<IFlowData>();
+
+            flowData.Setup(d => d.Get<IJsonBuilderElementData>())
+                .Throws<KeyNotFoundException>();
+            var evidence = new Evidence(_loggerFactory.CreateLogger<Evidence>()); 
+            flowData.Setup(d => d.GetEvidence())
+                .Returns(evidence);
+
+            var jsonData = new Mock<IJsonBuilderElementData>();
+            jsonData.Setup(j => j.Json)
+                .Returns("{}");
+
+            IJavaScriptBuilderElementData result = _javaScriptBuilderElement.GetFallbackResponse(flowData.Object, jsonData.Object);
+
+            Assert.IsFalse(string.IsNullOrWhiteSpace(result.JavaScript));
+        }
+
+        /// <summary>
+        /// Check that the callback URL is generated correctly.
+        /// </summary>
         /// <remarks>
         /// </remarks>
         [TestMethod]

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JsonBuilderElement/FlowElement/JsonBuilderElement.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JsonBuilderElement/FlowElement/JsonBuilderElement.cs
@@ -215,7 +215,27 @@ namespace FiftyOne.Pipeline.JsonBuilder.FlowElement
         /// <exception cref="ArgumentNullException">
         /// Thrown if the supplied flow data is null.
         /// </exception>
-        protected override void ProcessInternal(IFlowData data)
+        protected override void ProcessInternal(IFlowData data) =>
+            BuildAndInjectJSON(
+                data,
+                data.GetOrAdd(
+                    ElementDataKeyTyped,
+                    CreateElementData));
+
+        /// <summary>
+        /// Transform the data in the flow data instance into a
+        /// JSON object.
+        /// </summary>
+        /// <param name="data">
+        /// The <see cref="IFlowData"/>
+        /// </param>
+        /// <param name="elementData">
+        /// The <see cref="IJsonBuilderElementData"/>
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if the supplied flow data is null.
+        /// </exception>
+        private void BuildAndInjectJSON(IFlowData data, IJsonBuilderElementData elementData)
         {
             if (data == null) throw new ArgumentNullException(nameof(data));
 
@@ -225,11 +245,25 @@ namespace FiftyOne.Pipeline.JsonBuilder.FlowElement
                 config = _pipelineConfigs.GetOrAdd(data.Pipeline, config);
             }
 
-            var elementData = data.GetOrAdd(
-                    ElementDataKeyTyped,
-                    CreateElementData);
             var jsonString = BuildJson(data, config);
             elementData.Json = jsonString;
+        }
+
+        /// <summary>
+        /// Transform the data in the flow data instance into a
+        /// JSON object.
+        /// </summary>
+        /// <param name="data">
+        /// The <see cref="IFlowData"/>
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if the supplied flow data is null.
+        /// </exception>
+        public IJsonBuilderElementData GetFallbackResponse(IFlowData data)
+        {
+            var elementData = CreateElementData(data.Pipeline);
+            BuildAndInjectJSON(data, elementData);
+            return elementData;
         }
 
         /// <summary>

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JsonBuilderElementTests/JsonBuilderElementTests.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JsonBuilderElementTests/JsonBuilderElementTests.cs
@@ -99,6 +99,17 @@ namespace FiftyOne.Pipeline.JsonBuilderElementTests
         }
 
         /// <summary>
+        /// Check that the JSON produced by the JsonBuilder is valid.
+        /// </summary>
+        [TestMethod]
+        public void JsonBuilder_NonEmptyFallback()
+        {
+            var json = TestIteration(1, null, null, (e, fd) => ((JsonBuilderElement)e).GetFallbackResponse(fd).Json);
+
+            Assert.IsFalse(string.IsNullOrWhiteSpace(json));
+        }
+
+        /// <summary>
         /// Check that the JSON element removes JavaScript properties from the 
         /// response after max number of iterations has been reached.
         /// </summary>
@@ -731,7 +742,8 @@ carriage return and new line
 
         private string TestIteration(int iteration,
             Dictionary<string, object> data = null,
-            Mock<IFlowData> flowData = null)
+            Mock<IFlowData> flowData = null,
+            Func<IJsonBuilderElement, IFlowData, string> processFunc = null)
         {
             if(data == null)
             {
@@ -764,6 +776,11 @@ carriage return and new line
                     return result;
                 });
             flowData.Setup(d => d.Pipeline).Returns(_pipeline.Object);
+
+            if (processFunc != null)
+            {
+                return processFunc(_jsonBuilderElement, flowData.Object);
+            }
 
             _jsonBuilderElement.Process(flowData.Object);
 

--- a/FiftyOne.Pipeline.Web.Shared/Services/ClientsidePropertyService.cs
+++ b/FiftyOne.Pipeline.Web.Shared/Services/ClientsidePropertyService.cs
@@ -35,6 +35,8 @@ using FiftyOne.Pipeline.JsonBuilder.FlowElement;
 using System.Text;
 using FiftyOne.Pipeline.Web.Shared.Adapters;
 using Microsoft.Extensions.Logging;
+using FiftyOne.Pipeline.JavaScriptBuilder.Data;
+using FiftyOne.Pipeline.JsonBuilder.Data;
 
 namespace FiftyOne.Pipeline.Web.Shared.Services
 {
@@ -248,7 +250,15 @@ namespace FiftyOne.Pipeline.Web.Shared.Services
                             throw new PipelineConfigurationException(
                                 Messages.ExceptionNoJavaScriptBuilder);
                         }
-                        var jsData = flowData.GetFromElement(jsElement);
+                        IJavaScriptBuilderElementData jsData = null;
+                        try
+                        {
+                            jsData = flowData.GetFromElement(jsElement);
+                        }
+                        catch (PipelineException ex)
+                        {
+                            _logger?.LogError(ex, "Failed to get data from {flowElementType}", jsElement.GetType().Name);
+                        }
                         content = jsData?.JavaScript;
                         break;
                     case ContentType.Json:
@@ -258,7 +268,15 @@ namespace FiftyOne.Pipeline.Web.Shared.Services
                             throw new PipelineConfigurationException(
                                 Messages.ExceptionNoJsonBuilder);
                         }
-                        var jsonData = flowData.GetFromElement(jsonElement);
+                        IJsonBuilderElementData jsonData = null;
+                        try
+                        {
+                            jsonData = flowData.GetFromElement(jsonElement);
+                        }
+                        catch (PipelineException ex)
+                        {
+                            _logger?.LogError(ex, "Failed to get data from {flowElementType}", jsonElement.GetType().Name);
+                        }
                         content = jsonData?.Json;
                         break;
                     default:

--- a/FiftyOne.Pipeline.Web.Shared/Services/ClientsidePropertyService.cs
+++ b/FiftyOne.Pipeline.Web.Shared/Services/ClientsidePropertyService.cs
@@ -250,7 +250,7 @@ namespace FiftyOne.Pipeline.Web.Shared.Services
                             throw new PipelineConfigurationException(
                                 Messages.ExceptionNoJavaScriptBuilder);
                         }
-                        IJavaScriptBuilderElementData jsData = null;
+                        IJavaScriptBuilderElementData jsData;
                         try
                         {
                             jsData = flowData.GetFromElement(jsElement);
@@ -258,6 +258,7 @@ namespace FiftyOne.Pipeline.Web.Shared.Services
                         catch (PipelineException ex)
                         {
                             _logger?.LogError(ex, "Failed to get data from {flowElementType}", jsElement.GetType().Name);
+                            jsData = jsElement.GetFallbackResponse(flowData);
                         }
                         content = jsData?.JavaScript;
                         break;

--- a/FiftyOne.Pipeline.Web.Shared/Services/ClientsidePropertyService.cs
+++ b/FiftyOne.Pipeline.Web.Shared/Services/ClientsidePropertyService.cs
@@ -257,6 +257,7 @@ namespace FiftyOne.Pipeline.Web.Shared.Services
                     catch (PipelineException ex)
                     {
                         _logger?.LogError(ex, "Failed to get data from {flowElementType}", jsonElement.GetType().Name);
+                        jsonData = jsonElement.GetFallbackResponse(flowData);
                     }
                     return jsonData;
                 };

--- a/Web Integration/Tests/FiftyOne.Pipeline.Web.Shared.Tests/ClientsidePropertyServiceTests.cs
+++ b/Web Integration/Tests/FiftyOne.Pipeline.Web.Shared.Tests/ClientsidePropertyServiceTests.cs
@@ -437,6 +437,8 @@ namespace FiftyOne.Pipeline.Web.Shared.Tests
             }
             _pipeline.Setup(p => p.FlowElements)
                 .Returns(flowElements);
+            _pipeline.Setup(p => p.EvidenceKeyFilter)
+                .Returns(new EvidenceKeyFilterWhitelist(new List<string>()));
             // Configure the key for this flow data to contain a fake value
             // that we can use to test the cached response handling.
             _defaultDataKey = new DataKeyBuilder().Add(1, "test", "value").Build();


### PR DESCRIPTION
### Changes:
- Convert constructor-initialized field into lazy `HeadersAffectingJavaScript` property (ClientsidePropertyService).
- Add `org-name` to workflow files.
- Wrap multiple calls in try-catch to ensure stable returns of certain paths.
- Add mocking of additional (now-checked by main code) properties in Unit Tests.
- Add `GetFallbackResponse` methods to `JavaScriptBuilderElement` and `JsonBuilderElement` with respective Unit Tests.
- Use new methods when `data` is unprocessed or contains errors.

### Why:
- https://github.com/51Degrees/pipeline-dotnet/issues/75