### PR TITLE
Add Project URL into Nuget package

### DIFF
--- a/FiftyOne.Pipeline.Engines.TestHelpers/FiftyOne.Pipeline.Engines.TestHelpers.csproj
+++ b/FiftyOne.Pipeline.Engines.TestHelpers/FiftyOne.Pipeline.Engines.TestHelpers.csproj
@@ -14,6 +14,7 @@
 	<Copyright>51Degrees Mobile Experts Limited</Copyright>
 	<PackageTags>51degrees,pipeline,data service</PackageTags>
 	<RepositoryUrl>https://github.com/51Degrees/pipeline-dotnet</RepositoryUrl>
+	<PackageProjectUrl>https://51degrees.com</PackageProjectUrl>
   </PropertyGroup>
 
   <ItemGroup>

--- a/FiftyOne.Pipeline.Examples.Shared/FiftyOne.Pipeline.Examples.Shared.csproj
+++ b/FiftyOne.Pipeline.Examples.Shared/FiftyOne.Pipeline.Examples.Shared.csproj
@@ -18,6 +18,7 @@
 	<Copyright>51Degrees Mobile Experts Limited</Copyright>
 	<PackageTags>51degrees,pipeline,data service</PackageTags>
 	<RepositoryUrl>https://github.com/51Degrees/pipeline-dotnet</RepositoryUrl>
+	<PackageProjectUrl>https://51degrees.com</PackageProjectUrl>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Web Integration/FiftyOne.Pipeline.Web/FiftyOne.Pipeline.Web.csproj
+++ b/Web Integration/FiftyOne.Pipeline.Web/FiftyOne.Pipeline.Web.csproj
@@ -8,6 +8,7 @@
     <DocumentationFile>FiftyOne.Pipeline.Web.xml</DocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
+    <PackageProjectUrl>https://51degrees.com</PackageProjectUrl>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">


### PR DESCRIPTION
### Changes
- Set `PackageProjectUrl` to `https://51degrees.com`.

### Why
- https://github.com/51Degrees/device-detection-dotnet/issues/169