### PR TITLE
FEAT: The enable cookies option for `JavaScriptBuilderElement` is now configurable per-request.

### DIFF
--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElement/Constants.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElement/Constants.cs
@@ -51,6 +51,13 @@ namespace FiftyOne.Pipeline.JavaScriptBuilder
             "fod-js-object-name";
 
         /// <summary>
+        /// The suffix used when the <see cref="JavaScriptBuilderElement"/> 
+        /// 'enable cookies' parameter is supplied as evidence.
+        /// </summary>
+        public const string EVIDENCE_ENABLE_COOKIES_SUFFIX =
+            "fod-js-enable-cookies";
+
+        /// <summary>
         /// The complete key to be used when the 
         /// <see cref="JavaScriptBuilderElement"/> 'object name' 
         /// parameter is supplied as part of the query 
@@ -60,6 +67,17 @@ namespace FiftyOne.Pipeline.JavaScriptBuilder
             Core.Constants.EVIDENCE_QUERY_PREFIX +
             Core.Constants.EVIDENCE_SEPERATOR +
             EVIDENCE_OBJECT_NAME_SUFFIX;
+
+        /// <summary>
+        /// The complete key to be used when the 
+        /// <see cref="JavaScriptBuilderElement"/> 'enable cookies' 
+        /// parameter is supplied as part of the query 
+        /// string.
+        /// </summary>
+        public const string EVIDENCE_ENABLE_COOKIES =
+            Core.Constants.EVIDENCE_QUERY_PREFIX +
+            Core.Constants.EVIDENCE_SEPERATOR +
+            EVIDENCE_ENABLE_COOKIES_SUFFIX;
 
         /// <summary>
         /// The key to access the embedded resource that contains the 

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElement/FlowElement/JavaScriptBuilderElement.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElement/FlowElement/JavaScriptBuilderElement.cs
@@ -672,7 +672,17 @@ namespace FiftyOne.Pipeline.JavaScriptBuilder.FlowElement
                 objectName = objObjectName?.ToString() ?? ObjName;
             }
 
-            var ubdateEnabled = url != null &&
+            bool enableCookies = EnableCookies;
+            // Try and get the requested enable cookies option from evidence.
+            if (data.TryGetEvidence(Constants.EVIDENCE_ENABLE_COOKIES,
+                out object objEnableCookies))
+            {
+                enableCookies = objEnableCookies != null &&
+                    bool.TryParse(objEnableCookies.ToString(), out var boolEnableCookies) ?
+                    boolEnableCookies : EnableCookies;
+            }
+
+            var updateEnabled = url != null &&
                 url.AbsoluteUri.Length > 0;
 
             // This check won't be 100% fool-proof but it only needs to be 
@@ -689,8 +699,8 @@ namespace FiftyOne.Pipeline.JavaScriptBuilder.FlowElement
                 supportsFetch,
                 url,
                 parameters,
-                EnableCookies,
-                ubdateEnabled,
+                enableCookies,
+                updateEnabled,
                 hasDelayedProperties);
 
             string content = _stubble.Render(_template, javaScriptObj.AsDictionary());

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/CookiesTests.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/CookiesTests.cs
@@ -1,0 +1,144 @@
+﻿using FiftyOne.Common.TestHelpers;
+using FiftyOne.Pipeline.Core.Data;
+using FiftyOne.Pipeline.Core.FlowElements;
+using FiftyOne.Pipeline.Engines.FiftyOne.FlowElements;
+using FiftyOne.Pipeline.JavaScriptBuilder.Data;
+using FiftyOne.Pipeline.JavaScriptBuilder.FlowElement;
+using FiftyOne.Pipeline.JsonBuilder.FlowElement;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace FiftyOne.Pipeline.JavaScriptBuilderElementTests
+{
+    [TestClass]
+    public class CookiesTests
+    {
+        private TestLoggerFactory _loggerFactory = new TestLoggerFactory();
+
+        /// <summary>
+        /// Test element data that contains only javascript.
+        /// </summary>
+        private class CookieData : ElementDataBase
+        {
+            public CookieData(ILogger<ElementDataBase> logger, IPipeline pipeline) : base(logger, pipeline)
+            {
+            }
+
+            public string JavaScript => base.GetAs<string>("javascript");
+        }
+
+        /// <summary>
+        /// Test element that just adds some javascript to set a cookie.
+        /// </summary>
+        private class CookieElement : FlowElementBase<CookieData, ElementPropertyMetaData>
+        {
+            private readonly ILoggerFactory _loggerFactory;
+
+            public CookieElement(ILoggerFactory loggerFactory)
+                : base(loggerFactory.CreateLogger<FlowElementBase<CookieData, ElementPropertyMetaData>>())
+            {
+                _loggerFactory = loggerFactory;
+            }
+
+            public override string ElementDataKey => "cookie";
+
+            public override IEvidenceKeyFilter EvidenceKeyFilter =>
+                new EvidenceKeyFilterWhitelist(new List<string>());
+
+            public override IList<ElementPropertyMetaData> Properties =>
+                new List<ElementPropertyMetaData>()
+                {
+                    new ElementPropertyMetaData(
+                        this,
+                        "javascript",
+                        typeof(string),
+                        true)
+                };
+
+            protected override void ProcessInternal(IFlowData data)
+            {
+                var result = new CookieData(_loggerFactory.CreateLogger<CookieData>(), data.Pipeline);
+                result["javascript"] = "document.cookie =  \"some cookie value\"";
+                data.GetOrAdd(ElementDataKey, p => result);
+            }
+
+            protected override void ManagedResourcesCleanup()
+            {
+            }
+
+            protected override void UnmanagedResourcesCleanup()
+            {
+            }
+        }
+
+        /// <summary>
+        /// Test various configurations for enabling cookies to verify
+        /// that cookies are/aren't written for each configuration.
+        /// 
+        /// The source JavaScript contains code to set a cookie. The JSBuilder
+        /// element should replace this if the config says that cookies are not
+        /// enabled.
+        /// </summary>
+        /// <param name="enableInConfig">
+        /// True if cookies are enabled in the element configuration.
+        /// </param>
+        /// <param name="enableInEvidence">
+        /// True if cookies are enabled in the evidence.
+        /// </param>
+        /// <param name="expectCookie">
+        /// True if the test should expect cookies to be enabled for this configuration.
+        /// </param>
+        [DataRow(false, false, false)]
+        [DataRow(true, false, false)]
+        [DataRow(false, true, true)]
+        [DataRow(true, true, true)]
+        [DataTestMethod]
+        public void TestJavaScriptCookies(bool enableInConfig, bool enableInEvidence, bool expectCookie)
+        {
+            // Arrange
+            var cookieElement = new CookieElement(_loggerFactory);
+            var sequenceElement = new SequenceElementBuilder(_loggerFactory)
+                .Build();
+            var jsonElement = new JsonBuilderElementBuilder(_loggerFactory)
+                .Build();
+            var jsElement = new JavaScriptBuilderElementBuilder(_loggerFactory)
+                .SetEnableCookies(enableInConfig)
+                .Build();
+            var pipeline = new PipelineBuilder(_loggerFactory)
+                .AddFlowElement(cookieElement)
+                .AddFlowElement(sequenceElement)
+                .AddFlowElement(jsonElement)
+                .AddFlowElement(jsElement)
+                .Build();
+
+            // Act
+            string javaScript = null;
+            using (var flowData = pipeline.CreateFlowData())
+            {
+                flowData.AddEvidence(
+                    JavaScriptBuilder.Constants.EVIDENCE_ENABLE_COOKIES,
+                    enableInEvidence.ToString());
+                flowData.Process();
+                javaScript = flowData.Get<IJavaScriptBuilderElementData>().JavaScript;
+            }
+
+            // Assert
+            var cookieRegex = new Regex("document\\.cookie *= *");
+            if (expectCookie)
+            {
+                Assert.IsTrue(cookieRegex.IsMatch(javaScript));
+            }
+            else
+            {
+                Assert.IsFalse(cookieRegex.IsMatch(javaScript));
+            }
+        }
+    }
+}

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/CookiesTests.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/CookiesTests.cs
@@ -7,13 +7,8 @@ using FiftyOne.Pipeline.JavaScriptBuilder.FlowElement;
 using FiftyOne.Pipeline.JsonBuilder.FlowElement;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
 using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
 namespace FiftyOne.Pipeline.JavaScriptBuilderElementTests
 {
@@ -133,11 +128,15 @@ namespace FiftyOne.Pipeline.JavaScriptBuilderElementTests
             var cookieRegex = new Regex("document\\.cookie *= *");
             if (expectCookie)
             {
-                Assert.IsTrue(cookieRegex.IsMatch(javaScript));
+                Assert.IsTrue(
+                    cookieRegex.IsMatch(javaScript),
+                    "The original script to set cookies should not have been replaced.");
             }
             else
             {
-                Assert.IsFalse(cookieRegex.IsMatch(javaScript));
+                Assert.IsFalse(
+                    cookieRegex.IsMatch(javaScript),
+                    "The original script to set cookies should have been replaced.");
             }
         }
     }


### PR DESCRIPTION
Adding the query parameter `fod-js-enable-cookies` will override the option supplied to the element at construction.

This PR addresses #98 . However, the templates submodule will need to be update before the tests in this PR will pass.