### PR TITLE
TEST: Offset expected `document.cookie` occurrences by 1.

### DIFF
--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/CookiesTests.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/CookiesTests.cs
@@ -125,17 +125,20 @@ namespace FiftyOne.Pipeline.JavaScriptBuilderElementTests
             }
 
             // Assert
-            var cookieRegex = new Regex("document\\.cookie *= *");
+            var cookieRegex = new Regex("document\\.cookie");
+            var matches = cookieRegex.Matches(javaScript);
             if (expectCookie)
             {
-                Assert.IsTrue(
-                    cookieRegex.IsMatch(javaScript),
+                Assert.AreEqual(
+                    2,
+                    matches.Count,
                     "The original script to set cookies should not have been replaced.");
             }
             else
             {
-                Assert.IsFalse(
-                    cookieRegex.IsMatch(javaScript),
+                Assert.AreEqual(
+                    1,
+                    matches.Count,
                     "The original script to set cookies should have been replaced.");
             }
         }


### PR DESCRIPTION
This change set allows the tests introduced in https://github.com/51Degrees/pipeline-dotnet/pull/99 to pass after the merge of https://github.com/51Degrees/javascript-templates/pull/5 .