### PR TITLE
Use exact format for parsing `StarSign`.

### DIFF
--- a/Examples/CustomFlowElement/3. Client-side evidence/ClientSideEvidence.Shared/FlowElements/SimpleClientSideElement.cs
+++ b/Examples/CustomFlowElement/3. Client-side evidence/ClientSideEvidence.Shared/FlowElements/SimpleClientSideElement.cs
@@ -69,8 +69,8 @@ namespace Examples.ClientSideEvidence.Shared
             {
                 starSigns.Add(new StarSign(
                     starSign[0],
-                    DateTime.Parse(starSign[1]),
-                    DateTime.Parse(starSign[2])));
+                    DateTime.ParseExact(starSign[1], "dd/MM", null),
+                    DateTime.ParseExact(starSign[2], "dd/MM", null)));
             }
             _starSigns = starSigns;
         }


### PR DESCRIPTION
### Changes
- Replace `DateTime.Parse` calls with `DateTime.ParseExact`.

### Why
- The Example throws at different system locale settings:
```
Exception thrown: 'System.FormatException' in System.Private.CoreLib.dll
An exception of type 'System.FormatException' occurred in System.Private.CoreLib.dll but was not handled in user code
String '21/03' was not recognized as a valid DateTime.
```