### PR TITLE
Allow `PipelineBuilder` use extension methods.

### DIFF
--- a/Tests/FiftyOne.Pipeline.Core.Tests/FlowElements/PipelineBuilderTests.cs
+++ b/Tests/FiftyOne.Pipeline.Core.Tests/FlowElements/PipelineBuilderTests.cs
@@ -26,8 +26,10 @@ using FiftyOne.Pipeline.Core.Exceptions;
 using FiftyOne.Pipeline.Core.FlowElements;
 using FiftyOne.Pipeline.Core.Services;
 using FiftyOne.Pipeline.Core.Tests.HelperClasses;
+using FiftyOne.Pipeline.Core.Tests.HelperClasses.CompositeConfig;
 using FiftyOne.Pipeline.Engines.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;
@@ -578,6 +580,61 @@ namespace FiftyOne.Pipeline.Core.Tests.FlowElements
             // Pass the configuration to the builder to create the pipeline.
             var pipeline = new PipelineBuilder(_loggerFactory, services.Object)
                 .BuildFromConfiguration(opts);
+        }
+
+        [TestMethod]
+        public void PipelineBuilder_BuildFromConfiguration_Composite_ThroughExtensions()
+        {
+            var element = new ElementOptions()
+            {
+                BuilderName = "CompositeConfigElement"
+            };
+            element.BuildParameters.Add("Number", 42);
+            element.BuildParameters.Add("Text", "dummy");
+
+            // Create the configuration object.
+            PipelineOptions opts = new PipelineOptions();
+            opts.Elements = new List<ElementOptions>
+            {
+                element
+            };
+
+            var pipeline = _builder.BuildFromConfiguration(opts);
+            var builtElement = pipeline.GetElement<CompositeConfigElement>();
+            Assert.AreEqual(42, builtElement.Number);
+            Assert.AreEqual("dummy", builtElement.Text);
+        }
+
+        [TestMethod]
+        public void PipelineBuilder_BuildFromConfiguration_Composite_NoValues()
+        {
+            var element = new ElementOptions()
+            {
+                BuilderName = "CompositeConfigElement"
+            };
+
+            // Create the configuration object.
+            PipelineOptions opts = new PipelineOptions();
+            opts.Elements = new List<ElementOptions>
+            {
+                element
+            };
+
+            var pipeline = _builder.BuildFromConfiguration(opts);
+            var builtElement = pipeline.GetElement<CompositeConfigElement>();
+            Assert.AreEqual(0, builtElement.Number);
+            Assert.IsNull(builtElement.Text);
+        }
+
+        [TestMethod]
+        public void PipelineBuilder_BuildFromConfiguration_Composite_BuilderControl()
+        {
+            var builtElement = new CompositeConfigElementBuilder()
+                .SetNumber(88888888)
+                .SetText("Lucky")
+                .Build() as CompositeConfigElement;
+            Assert.AreEqual(88888888, builtElement.Number);
+            Assert.AreEqual("Lucky", builtElement.Text);
         }
 
         /// <summary>

--- a/Tests/FiftyOne.Pipeline.Core.Tests/FlowElements/PipelineBuilderTests.cs
+++ b/Tests/FiftyOne.Pipeline.Core.Tests/FlowElements/PipelineBuilderTests.cs
@@ -29,7 +29,6 @@ using FiftyOne.Pipeline.Core.Tests.HelperClasses;
 using FiftyOne.Pipeline.Core.Tests.HelperClasses.CompositeConfig;
 using FiftyOne.Pipeline.Engines.Services;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;

--- a/Tests/FiftyOne.Pipeline.Core.Tests/HelperClasses/CompositeConfig/CompositeConfigElement.cs
+++ b/Tests/FiftyOne.Pipeline.Core.Tests/HelperClasses/CompositeConfig/CompositeConfigElement.cs
@@ -1,0 +1,39 @@
+﻿using FiftyOne.Pipeline.Core.Data;
+using FiftyOne.Pipeline.Core.FlowElements;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Collections.Generic;
+
+namespace FiftyOne.Pipeline.Core.Tests.HelperClasses.CompositeConfig
+{
+    public class CompositeConfigElement : FlowElementBase<TestElementData, IElementPropertyMetaData>
+    {
+        public override string ElementDataKey => "compositeConfig";
+
+        public override IEvidenceKeyFilter EvidenceKeyFilter => new EvidenceKeyFilterWhitelist(new List<string>());
+
+        public override IList<IElementPropertyMetaData> Properties => new List<IElementPropertyMetaData>();
+
+        public int Number { get; private set; }
+        public string Text { get; private set; }
+
+        public CompositeConfigElement(int number, string text) :
+            base(new Mock<ILogger<CompositeConfigElement>>().Object)
+        {
+            Number = number;
+            Text = text;
+        }
+
+        protected override void ProcessInternal(IFlowData data)
+        {
+        }
+
+        protected override void ManagedResourcesCleanup()
+        {
+        }
+
+        protected override void UnmanagedResourcesCleanup()
+        {
+        }
+    }
+}

--- a/Tests/FiftyOne.Pipeline.Core.Tests/HelperClasses/CompositeConfig/CompositeConfigElementBuilder.cs
+++ b/Tests/FiftyOne.Pipeline.Core.Tests/HelperClasses/CompositeConfig/CompositeConfigElementBuilder.cs
@@ -1,0 +1,21 @@
+﻿using FiftyOne.Pipeline.Core.FlowElements;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FiftyOne.Pipeline.Core.Tests.HelperClasses.CompositeConfig
+{
+    public class CompositeConfigElementBuilder: ICompositeConfigFragmentContainer
+    {
+        private CompositeConfigFragment _configFragment = new CompositeConfigFragment();
+
+        public IFlowElement Build()
+        {
+            return new CompositeConfigElement(_configFragment.Number, _configFragment.Text);
+        }
+
+        public CompositeConfigFragment getOrMakeCompositeConfigFragment() => _configFragment;
+    }
+}

--- a/Tests/FiftyOne.Pipeline.Core.Tests/HelperClasses/CompositeConfig/CompositeConfigElementBuilder.cs
+++ b/Tests/FiftyOne.Pipeline.Core.Tests/HelperClasses/CompositeConfig/CompositeConfigElementBuilder.cs
@@ -1,9 +1,4 @@
 ﻿using FiftyOne.Pipeline.Core.FlowElements;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FiftyOne.Pipeline.Core.Tests.HelperClasses.CompositeConfig
 {

--- a/Tests/FiftyOne.Pipeline.Core.Tests/HelperClasses/CompositeConfig/CompositeConfigFragment.cs
+++ b/Tests/FiftyOne.Pipeline.Core.Tests/HelperClasses/CompositeConfig/CompositeConfigFragment.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FiftyOne.Pipeline.Core.Tests.HelperClasses.CompositeConfig
+{
+    public class CompositeConfigFragment
+    {
+        public int Number { get; set; } = 0;
+        public string Text { get; set; } = null;
+    }
+}

--- a/Tests/FiftyOne.Pipeline.Core.Tests/HelperClasses/CompositeConfig/CompositeConfigFragment.cs
+++ b/Tests/FiftyOne.Pipeline.Core.Tests/HelperClasses/CompositeConfig/CompositeConfigFragment.cs
@@ -1,9 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace FiftyOne.Pipeline.Core.Tests.HelperClasses.CompositeConfig
 {
     public class CompositeConfigFragment

--- a/Tests/FiftyOne.Pipeline.Core.Tests/HelperClasses/CompositeConfig/ICompositeConfigFragmentContainer.cs
+++ b/Tests/FiftyOne.Pipeline.Core.Tests/HelperClasses/CompositeConfig/ICompositeConfigFragmentContainer.cs
@@ -1,9 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace FiftyOne.Pipeline.Core.Tests.HelperClasses.CompositeConfig
 {
     public interface ICompositeConfigFragmentContainer

--- a/Tests/FiftyOne.Pipeline.Core.Tests/HelperClasses/CompositeConfig/ICompositeConfigFragmentContainer.cs
+++ b/Tests/FiftyOne.Pipeline.Core.Tests/HelperClasses/CompositeConfig/ICompositeConfigFragmentContainer.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FiftyOne.Pipeline.Core.Tests.HelperClasses.CompositeConfig
+{
+    public interface ICompositeConfigFragmentContainer
+    {
+        CompositeConfigFragment getOrMakeCompositeConfigFragment();
+    }
+
+    public static class CompositeConfigFragmentExtensions
+    {
+        public static T SetNumber<T>(this T builder, int number) where T : ICompositeConfigFragmentContainer
+        {
+            builder.getOrMakeCompositeConfigFragment().Number = number;
+            return builder;
+        }
+
+        public static T SetText<T>(this T builder, string text) where T : ICompositeConfigFragmentContainer
+        {
+            builder.getOrMakeCompositeConfigFragment().Text = text;
+            return builder;
+        }
+    }
+}


### PR DESCRIPTION
### Changes
- Modify `PipelineBuilder` to also search for suitable extension setter-methods (in the same assembly as builder type).
- Add example:
  - `CompositeConfigElementBuilder` class with
  - reusable options subsection (`CompositeConfigFragment`)
  - that is "inlined" at code completion level by `CompositeConfigFragmentExtensions`
  - and `ICompositeConfigFragmentContainer` "trait" (applied to `CompositeConfigElementBuilder`).
- Add 3 unit tests:
  - (control) Check the `CompositeConfigElementBuilder` directly (no `PipelineBuilder` used).
  - (control) Check `PipelineBuilder` finding `CompositeConfigElementBuilder` (no properties set yet).
  - (actual) Check `PipelineBuilder` using the builder extension methods (supplied to `CompositeConfigElementBuilder` by `CompositeConfigFragmentExtensions` via implementation of `ICompositeConfigFragmentContainer` "trait").
- Rewrite explicit 3-step switch in `PipelineBuilder.GetMethods` into `IEnumerable` generator `FindPotentialMethods` with `yield` statements.

### Why
- Related to supporting S3 in [[CloudShareUsageBuilder](https://github.com/51Degrees/cloud-dotnet/blob/main/FiftyOne.Pipeline.Cloud.ShareUsage/FlowElement/CloudShareUsageBuilder.cs#L13)]:
  - Will enable moving existing (`ShareUsageConnectionString`, `Container`) properties out, together with the new ones (`S3AccessKey`, `S3SecretKey`, `S3Region`, `S3BucketName`) into a single reusable section, and implement validation logic at _that_ level (i.e. also reusable with the section itself) while keeping "setters" appear (at compilation and config levels) on the builder itself.
