### PR TITLE
BUG: `ToString` method in `AspectPropertyValue` does not prevent exception.

### DIFF
--- a/FiftyOne.Pipeline.Engines/Data/AspectPropertyValue.cs
+++ b/FiftyOne.Pipeline.Engines/Data/AspectPropertyValue.cs
@@ -132,7 +132,7 @@ namespace FiftyOne.Pipeline.Engines.Data
         /// </exception>
         public override string ToString()
         {
-            return Value?.ToString() ?? "NULL";
+            return HasValue ? Value.ToString() : "NULL";
         }
 
         /// <summary>


### PR DESCRIPTION
Instead of checking the `HasValue` flag, `Value` was compared to `null`. The getter for `Value` throws an exception is `HasValue` is false. So this is now checked instead.