### PR TITLE
Replace `catch (PipelineException e)` with `catch (Exception e)`.

### DIFF
--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JsonBuilderElement/FlowElement/JsonBuilderElement.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JsonBuilderElement/FlowElement/JsonBuilderElement.cs
@@ -298,7 +298,7 @@ namespace FiftyOne.Pipeline.JsonBuilder.FlowElement
             {
                 sequenceNumber = GetSequenceNumber(data);
             }
-            catch (PipelineException e)
+            catch (Exception e)
             {
                 if (requireSequenceNumber)
                 {

--- a/FiftyOne.Pipeline.Web.Shared/Services/ClientsidePropertyService.cs
+++ b/FiftyOne.Pipeline.Web.Shared/Services/ClientsidePropertyService.cs
@@ -220,7 +220,7 @@ namespace FiftyOne.Pipeline.Web.Shared.Services
             {
                 pipelineEvidenceKeyFilter = _pipeline.EvidenceKeyFilter;
             }
-            catch (PipelineException ex)
+            catch (Exception ex)
             {
                 _logger?.LogError(ex, $"Failed to get {nameof(_pipeline.EvidenceKeyFilter)} from {nameof(_pipeline)}");
                 hadFailures = true;
@@ -257,7 +257,7 @@ namespace FiftyOne.Pipeline.Web.Shared.Services
                     {
                         jsonData = flowData.GetFromElement(jsonElement);
                     }
-                    catch (PipelineException ex)
+                    catch (Exception ex)
                     {
                         _logger?.LogError(ex, "Failed to get data from {flowElementType}", jsonElement.GetType().Name);
                         jsonData = jsonElement.GetFallbackResponse(flowData);
@@ -279,7 +279,7 @@ namespace FiftyOne.Pipeline.Web.Shared.Services
                     {
                         jsData = flowData.GetFromElement(jsElement);
                     }
-                    catch (PipelineException ex)
+                    catch (Exception ex)
                     {
                         _logger?.LogError(ex, "Failed to get data from {flowElementType}", jsElement.GetType().Name);
                         jsData = jsElement.GetFallbackResponse(flowData, GetJsonData());

--- a/Web Integration/FiftyOne.Pipeline.Web.Framework/WebPipeline.cs
+++ b/Web Integration/FiftyOne.Pipeline.Web.Framework/WebPipeline.cs
@@ -242,7 +242,7 @@ namespace FiftyOne.Pipeline.Web.Framework
                 {
                     filler = new EvidenceFiller(flowData);
                 }
-                catch (PipelineException ex)
+                catch (Exception ex)
                 {
                     flowData.AddError(ex, null);
                     throw;


### PR DESCRIPTION
Allows for ArgumentNullException / ArgumentException / KeyNotFoundException as well.

See
- https://github.com/51Degrees/pipeline-dotnet/blob/main/FiftyOne.Pipeline.Core/Data/FlowData.cs#L497-L501
- https://github.com/51Degrees/pipeline-dotnet/blob/main/FiftyOne.Pipeline.Core/TypedMap/TypedKeyMap.cs#L126-L145