### PR TITLE
Fix updates of "AspNet Framework MVC Example"

### DIFF
--- a/Examples/UsageSharing/Examples.UsageSharing.csproj
+++ b/Examples/UsageSharing/Examples.UsageSharing.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FiftyOne.Pipeline.Core/FiftyOne.Pipeline.Core.csproj
+++ b/FiftyOne.Pipeline.Core/FiftyOne.Pipeline.Core.csproj
@@ -34,8 +34,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/JavaScriptBuilderElementTemplateTests.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/JavaScriptBuilderElementTemplateTests.cs
@@ -145,7 +145,7 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
 
         [TestMethod]
         [DynamicData(nameof(GetValidateSetCookieBlockData), DynamicDataSourceType.Method)]
-        [Timeout(300_000)]
+        [Timeout(600_000)]
         public void JavaScriptBuilderTemplate_ValidateSetCookieBlockCall(
             string propName,
             string prefixJunk,

--- a/Tests/FiftyOne.Pipeline.Engines.FiftyOne.Tests/FiftyOne.Pipeline.Engines.FiftyOne.Tests.csproj
+++ b/Tests/FiftyOne.Pipeline.Engines.FiftyOne.Tests/FiftyOne.Pipeline.Engines.FiftyOne.Tests.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="FiftyOne.Common.TestHelpers" Version="4.4.18" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />

--- a/Web Integration/Examples/ExampleFrameworkWebsite/AspNet Framework MVC Example.csproj
+++ b/Web Integration/Examples/ExampleFrameworkWebsite/AspNet Framework MVC Example.csproj
@@ -152,7 +152,6 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
   <Target Name="MvcBuildViews" AfterTargets="AfterBuild" Condition="'$(MvcBuildViews)'=='true'">
     <AspNetCompiler VirtualPath="temp" PhysicalPath="$(WebProjectOutputDir)" />

--- a/Web Integration/Examples/ExampleFrameworkWebsite/AspNet Framework MVC Example.csproj
+++ b/Web Integration/Examples/ExampleFrameworkWebsite/AspNet Framework MVC Example.csproj
@@ -134,9 +134,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FiftyOne.Common">
-      <Version>4.4.17</Version>
-    </PackageReference>
+    <PackageReference Include="FiftyOne.Common" Version="4.4.19" />
     <PackageReference Include="Microsoft.AspNet.Mvc">
       <Version>5.2.9</Version>
     </PackageReference>

--- a/Web Integration/FiftyOne.Pipeline.Web.Framework/FiftyOne.Pipeline.Web.Framework.csproj
+++ b/Web Integration/FiftyOne.Pipeline.Web.Framework/FiftyOne.Pipeline.Web.Framework.csproj
@@ -107,15 +107,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions">
-      <Version>6.0.0</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json">
-      <Version>6.0.0</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Xml">
-      <Version>6.0.0</Version>
-    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions">
       <Version>6.0.4</Version>
     </PackageReference>

--- a/Web Integration/FiftyOne.Pipeline.Web/FiftyOne.Pipeline.Web.csproj
+++ b/Web Integration/FiftyOne.Pipeline.Web/FiftyOne.Pipeline.Web.csproj
@@ -31,14 +31,14 @@
 	     update the dependencies in the nuspec file in the parent directory. -->
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.32" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="6.0.35" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="6.0.36" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
     <!-- If these package references are updated or modified then don't forget to also 
 	     update the dependencies in the nuspec file in the parent directory. -->
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.35" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="6.0.35" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.36" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="6.0.36" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\README.md">

--- a/Web Integration/Tests/FiftyOne.Pipeline.Web.Framework.Tests/app.config
+++ b/Web Integration/Tests/FiftyOne.Pipeline.Web.Framework.Tests/app.config
@@ -3,6 +3,10 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1"/>
+      </dependentAssembly>
+      <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.4" newVersion="6.0.0.4"/>
       </dependentAssembly>

--- a/Web Integration/Tests/FiftyOne.Pipeline.Web.Framework.Tests/app.config
+++ b/Web Integration/Tests/FiftyOne.Pipeline.Web.Framework.Tests/app.config
@@ -3,7 +3,23 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Configuration" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.2" newVersion="6.0.0.2"/>
+      </dependentAssembly>
+      <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.FileExtensions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.FileProviders.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.FileProviders.Physical" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1"/>
       </dependentAssembly>
       <dependentAssembly>
@@ -11,8 +27,20 @@
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.4" newVersion="6.0.0.4"/>
       </dependentAssembly>
       <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1"/>
+      </dependentAssembly>
+      <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.11" newVersion="6.0.0.11"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Web Integration/Tests/FiftyOne.Pipeline.Web.Tests/FiftyOne.Pipeline.Web.Tests.csproj
+++ b/Web Integration/Tests/FiftyOne.Pipeline.Web.Tests/FiftyOne.Pipeline.Web.Tests.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />


### PR DESCRIPTION
### Changes
- Remove import that failed package updates
  - `$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets`
- Update packages
- Add more binding redirects to `FiftyOne.Pipeline.Web.Framework.Tests`
- Increase timeout `JavaScriptBuilderTemplate_ValidateSetCookieBlockCall` _(cause Ubuntu runner failed twice in a row)_

### Why
- https://github.com/51Degrees/pipeline-dotnet/actions/runs/11965618613/job/33359937813#step:5:1035
- https://github.com/postindustria-tech/pipeline-dotnet/actions/workflows/nightly-prs-to-main.yml
  > WARNING: error: The imported project "/usr/share/dotnet/sdk/8.0.404/Microsoft/VisualStudio/v17.0/WebApplications/Microsoft.WebApplication.targets" was not found. Confirm that the expression in the Import declaration "/usr/share/dotnet/sdk/8.0.404/Microsoft/VisualStudio/v17.0/WebApplications/Microsoft.WebApplication.targets" is correct, and that the file exists on disk.  /home/runner/work/pipeline-dotnet/pipeline-dotnet/common/pipeline-dotnet/Web Integration/Examples/ExampleFrameworkWebsite/AspNet Framework MVC Example.csproj

### Proofs
- ✅ https://github.com/postindustria-tech/pipeline-dotnet/actions/runs/11978649119

### Related:
- https://github.com/51Degrees/pipeline-dotnet/pull/143 -- to be superseded by this PR