### PR TITLE
Enable build on macos-13 runners

### DIFF
--- a/FiftyOne.Pipeline.Core/FlowElements/FlowElementBase.cs
+++ b/FiftyOne.Pipeline.Core/FlowElements/FlowElementBase.cs
@@ -28,6 +28,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Linq;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace FiftyOne.Pipeline.Core.FlowElements
 {
@@ -184,11 +185,8 @@ namespace FiftyOne.Pipeline.Core.FlowElements
             ILogger<FlowElementBase<T, TMeta>> logger,
             Func<IPipeline, FlowElementBase<T, TMeta>, T> elementDataFactory)
         {
-            Logger = logger;
-            if (Logger != null)
-            {
-                Logger.LogInformation($"FlowElement '{GetType().Name}' created.");
-            }
+            Logger = logger ?? NullLogger<FlowElementBase<T, TMeta>>.Instance;
+            Logger.LogInformation($"FlowElement '{GetType().Name}' created.");
             _elementDataFactory = elementDataFactory;
         }
 

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JsonBuilderElementTests/FiftyOne.Pipeline.JsonBuilderElementTests.csproj
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JsonBuilderElementTests/FiftyOne.Pipeline.JsonBuilderElementTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/FiftyOne.Pipeline.Engines/Services/DataUpdateService.cs
+++ b/FiftyOne.Pipeline.Engines/Services/DataUpdateService.cs
@@ -263,8 +263,12 @@ namespace FiftyOne.Pipeline.Engines.Services
                         FileSystemWatcher watcher = new FileSystemWatcher(
 							Path.GetDirectoryName(dataFile.DataFilePath),
 							Path.GetFileName(dataFile.DataFilePath));
-						watcher.NotifyFilter = NotifyFilters.LastWrite;
+
+						//on macos NotifyFilters.FileName filter and Created subscription are needed
+						//because it seems to recreate the file when copying over
+						watcher.NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName;
 						watcher.Changed += DataFileUpdated;
+						watcher.Created += DataFileUpdated;
 						watcher.EnableRaisingEvents = true;
 						dataFile.FileWatcher = watcher;
 					}

--- a/Tests/FiftyOne.Pipeline.Benchmarks/FiftyOne.Pipeline.Benchmarks.csproj
+++ b/Tests/FiftyOne.Pipeline.Benchmarks/FiftyOne.Pipeline.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Tests/FiftyOne.Pipeline.CloudRequestEngine.Examples.Tests/FiftyOne.Pipeline.CloudRequestEngine.Examples.Tests.csproj
+++ b/Tests/FiftyOne.Pipeline.CloudRequestEngine.Examples.Tests/FiftyOne.Pipeline.CloudRequestEngine.Examples.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Tests/FiftyOne.Pipeline.CloudRequestEngine.Tests/FiftyOne.Pipeline.CloudRequestEngine.Tests.csproj
+++ b/Tests/FiftyOne.Pipeline.CloudRequestEngine.Tests/FiftyOne.Pipeline.CloudRequestEngine.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Tests/FiftyOne.Pipeline.Core.Tests/FiftyOne.Pipeline.Core.Tests.csproj
+++ b/Tests/FiftyOne.Pipeline.Core.Tests/FiftyOne.Pipeline.Core.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 	
     <IsPackable>false</IsPackable>
 	

--- a/Tests/FiftyOne.Pipeline.Engines.FiftyOne.Tests/FiftyOne.Pipeline.Engines.FiftyOne.Tests.csproj
+++ b/Tests/FiftyOne.Pipeline.Engines.FiftyOne.Tests/FiftyOne.Pipeline.Engines.FiftyOne.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/Tests/FiftyOne.Pipeline.Engines.FiftyOne.Tests/FlowElements/ShareUsageElementTests.cs
+++ b/Tests/FiftyOne.Pipeline.Engines.FiftyOne.Tests/FlowElements/ShareUsageElementTests.cs
@@ -38,6 +38,7 @@ using FiftyOne.Common.TestHelpers;
 using FiftyOne.Pipeline.Engines.TestHelpers;
 using System;
 using System.Linq;
+using System.Threading;
 
 namespace FiftyOne.Pipeline.Engines.FiftyOne.Tests.FlowElements
 {
@@ -310,6 +311,9 @@ namespace FiftyOne.Pipeline.Engines.FiftyOne.Tests.FlowElements
                 requiredEvents <= 1000000)
             {
                 _shareUsageElement.Process(data.Object);
+                if (requiredEvents % 200000 == 0) {
+                    Thread.Sleep(1000);
+                }
                 requiredEvents++;
             }
             // Wait for the consumer task to finish.
@@ -321,6 +325,7 @@ namespace FiftyOne.Pipeline.Engines.FiftyOne.Tests.FlowElements
             // 100,000. However, as it's chance based it can vary 
             // significantly. We only want to catch any gross errors so just
             // make sure the value is of the expected order of magnitude.
+            Console.WriteLine($"requiredEvents = {requiredEvents}");
             Assert.IsTrue(requiredEvents > 10000, $"Expected the number of required " +
                 $"events to be at least 10,000, but was actually '{requiredEvents}'");
             Assert.IsTrue(requiredEvents < 1000000, $"Expected the number of required " +

--- a/Tests/FiftyOne.Pipeline.Engines.Tests/FiftyOne.Pipeline.Engines.Tests.csproj
+++ b/Tests/FiftyOne.Pipeline.Engines.Tests/FiftyOne.Pipeline.Engines.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/Tests/FiftyOne.Pipeline.Engines.Tests/Services/DataUpdateServiceTests.cs
+++ b/Tests/FiftyOne.Pipeline.Engines.Tests/Services/DataUpdateServiceTests.cs
@@ -443,10 +443,13 @@ namespace FiftyOne.Pipeline.Engines.Tests.Services
                 string temp2 = Path.GetTempFileName();
                 File.WriteAllText(temp2, "Testing");
                 File.Copy(temp2, tempData, true);
+                
                 // Wait until processing is complete.
                 completeFlag.Wait(TEST_TIMEOUT_MS);
 
                 DumpLoggerLogs();
+                
+                //Wait until logging is done.
 
                 // Assert
                 Assert.IsTrue(completeFlag.IsSet, "The 'CheckForUpdateComplete' " +
@@ -470,7 +473,7 @@ namespace FiftyOne.Pipeline.Engines.Tests.Services
             finally
             {
                 // Make sure we tidy up the temp file.
-                if (File.Exists(tempData)) { File.Delete(tempData); }
+                //if (File.Exists(tempData)) { File.Delete(tempData); }
             }
         }
 

--- a/Tests/FiftyOne.Pipeline.Examples.Tests/FiftyOne.Pipeline.Examples.Tests.csproj
+++ b/Tests/FiftyOne.Pipeline.Examples.Tests/FiftyOne.Pipeline.Examples.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/Web Integration/Examples/NetCore/AspNetCore Example.csproj
+++ b/Web Integration/Examples/NetCore/AspNetCore Example.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>AspNetCore_Example</RootNamespace>
     <AssemblyName>AspNetCore_Example</AssemblyName>
   </PropertyGroup>

--- a/Web Integration/Tests/FiftyOne.Pipeline.Web.Shared.Tests/FiftyOne.Pipeline.Web.Shared.Tests.csproj
+++ b/Web Integration/Tests/FiftyOne.Pipeline.Web.Shared.Tests/FiftyOne.Pipeline.Web.Shared.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Web Integration/Tests/FiftyOne.Pipeline.Web.Tests/FiftyOne.Pipeline.Web.Tests.csproj
+++ b/Web Integration/Tests/FiftyOne.Pipeline.Web.Tests/FiftyOne.Pipeline.Web.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/ci/options.json
+++ b/ci/options.json
@@ -29,7 +29,7 @@
         "Arch": "Any CPU",
         "BuildMethod": "dotnet"
     },
-        {
+    {
         "Image": "ubuntu-22.04",
         "Name": "Ubuntu_AnyCPU_Release",
         "Configuration": "CoreRelease",
@@ -40,6 +40,20 @@
     {
         "Image": "ubuntu-22.04",
         "Name": "Ubuntu_AnyCPU_Debug",
+        "Configuration": "CoreDebug",
+        "Arch": "Any CPU",
+        "BuildMethod": "dotnet"
+    },
+    {
+        "Image": "macos-13",
+        "Name": "macos_AnyCPU_Release",
+        "Configuration": "CoreRelease",
+        "Arch": "Any CPU",
+        "BuildMethod": "dotnet",
+    },
+    {
+        "Image": "macos-13",
+        "Name": "macos_AnyCPU_Debug",
         "Configuration": "CoreDebug",
         "Arch": "Any CPU",
         "BuildMethod": "dotnet"


### PR DESCRIPTION
Changes:
* update test and example projects to target .NET 8.0
* address an instability in ShareUsageElementTests
* fix FileSystemWatcher in DataFileUpdateService.cs to track a copy over event on macos which otherwise was not triggered.  the essential changed lines in that file are:
```csharp
watcher.NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName;
watcher.Created += DataFileUpdated;
```
all others are whitespace and line endings due to auto-formatting in the IDE
* introduce NullLogger into FlowElementBase - otherwise it crashed in Finalize() because logger was unavailable