### PR TITLE
introduce IData.PopulateFrom(IEnumerable) + a property visibility change on JavaScriptBuilderElementBuilder

### DIFF
--- a/FiftyOne.Pipeline.CloudRequestEngine/FlowElements/PropertyKeyedCloudEngineBase.cs
+++ b/FiftyOne.Pipeline.CloudRequestEngine/FlowElements/PropertyKeyedCloudEngineBase.cs
@@ -120,7 +120,7 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.FlowElements
                     propertyValues, 
                     propertyMetaData);
 
-                device.PopulateFromDictionary(deviceData);
+                device.PopulateFrom(deviceData);
                 //device.SetNoValueReasons(nullReasons);
                 aspectData.AddProfile(device);
             }

--- a/FiftyOne.Pipeline.Core/Data/DataBase.cs
+++ b/FiftyOne.Pipeline.Core/Data/DataBase.cs
@@ -124,7 +124,7 @@ namespace FiftyOne.Pipeline.Core.Data
         }
 
         /// <summary>
-        /// Use the values in the specified dictionary to populate
+        /// Use the values in the specified enumerable to populate
         /// this data instance.
         /// </summary>
         /// <remarks>
@@ -138,16 +138,35 @@ namespace FiftyOne.Pipeline.Core.Data
         /// <exception cref="ArgumentNullException">
         /// Thrown if the supplied dictionary is null
         /// </exception>
-        public void PopulateFromDictionary(IDictionary<string, object> values)
+        public void PopulateFrom(IEnumerable<KeyValuePair<string, object>> values)
         {
-            if(values == null)
+            if (values == null)
             {
                 throw new ArgumentNullException(nameof(values));
             }
-            foreach(var value in values)
+
+            foreach (var value in values)
             {
                 this[value.Key] = value.Value;
             }
+        }
+        /// <summary>
+        /// Deprecated. Use PopulateFrom method.
+        /// Use the values in the specified dictionary to populate
+        /// this data instance.
+        /// </summary>
+        /// <remarks>
+        /// The data will not be cleared before the new values are added.
+        /// The new values will overwrite old values if any exist with the
+        /// same keys.
+        /// </remarks>
+        /// <param name="values">
+        /// The values to transfer to this data instance.
+        /// </param>
+        [Obsolete("PopulateFromDictionary is deprecated. Use PopulateFrom(IEnumerable<KeyValuePair<string, object>>) instead.")]
+        public void PopulateFromDictionary(IDictionary<string, object> values)
+        {
+            PopulateFrom(values);
         }
 
         /// <summary>

--- a/FiftyOne.Pipeline.Core/Data/IData.cs
+++ b/FiftyOne.Pipeline.Core/Data/IData.cs
@@ -20,6 +20,7 @@
  * such notice(s) shall fulfill the requirements of that article.
  * ********************************************************************* */
 
+using System;
 using System.Collections.Generic;
 
 namespace FiftyOne.Pipeline.Core.Data
@@ -39,6 +40,20 @@ namespace FiftyOne.Pipeline.Core.Data
         IReadOnlyDictionary<string, object> AsDictionary();
 
         /// <summary>
+        /// Use the values in the specified enumerable to populate
+        /// this data instance.
+        /// </summary>
+        /// <remarks>
+        /// The data will not be cleared before the new values are added.
+        /// The new values will overwrite old values if any exist with the
+        /// same keys.
+        /// </remarks>
+        /// <param name="values">
+        /// The key-value pairs to transfer to this data instance.
+        /// </param>
+        void PopulateFrom(IEnumerable<KeyValuePair<string, object>> values);
+
+        /// <summary>
         /// Use the values in the specified dictionary to populate
         /// this data instance.
         /// </summary>
@@ -50,6 +65,7 @@ namespace FiftyOne.Pipeline.Core.Data
         /// <param name="values">
         /// The values to transfer to this data instance.
         /// </param>
+        [Obsolete("PopulateFromDictionary is deprecated. Use PopulateFrom(IEnumerable<KeyValuePair<string, object>>) instead.")]
         void PopulateFromDictionary(IDictionary<string, object> values);
 
         /// <summary>

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElement/FlowElement/JavaScriptBuilderElementBuilder.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElement/FlowElement/JavaScriptBuilderElementBuilder.cs
@@ -38,6 +38,9 @@ namespace FiftyOne.Pipeline.JavaScriptBuilder.FlowElement
     /// </summary>
     public class JavaScriptBuilderElementBuilder
     {
+        /// <summary>
+        /// Logger factory that may be reused in descendants to produce a distinct logger.
+        /// </summary>
         protected ILoggerFactory _loggerFactory;
         private ILogger<JavaScriptBuilderElementData> _dataLogger; 
 

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElement/FlowElement/JavaScriptBuilderElementBuilder.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElement/FlowElement/JavaScriptBuilderElementBuilder.cs
@@ -38,7 +38,7 @@ namespace FiftyOne.Pipeline.JavaScriptBuilder.FlowElement
     /// </summary>
     public class JavaScriptBuilderElementBuilder
     {
-        private ILoggerFactory _loggerFactory;
+        protected ILoggerFactory _loggerFactory;
         private ILogger<JavaScriptBuilderElementData> _dataLogger; 
 
         /// <summary>

--- a/FiftyOne.Pipeline.Engines.TestHelpers/MockFlowData.cs
+++ b/FiftyOne.Pipeline.Engines.TestHelpers/MockFlowData.cs
@@ -46,7 +46,7 @@ namespace FiftyOne.Pipeline.Engines.TestHelpers
         {
             LoggerFactory factory = new LoggerFactory();
             Evidence evidence = new Evidence(factory.CreateLogger<Evidence>());
-            evidence.PopulateFromDictionary(evidenceData);
+            evidence.PopulateFrom(evidenceData);
 
             Mock<IFlowData> data = new Mock<IFlowData>();
             data.Setup(d => d.GetEvidence()).Returns(evidence);

--- a/FiftyOne.Pipeline.Engines/Services/DataUpdateService.cs
+++ b/FiftyOne.Pipeline.Engines/Services/DataUpdateService.cs
@@ -1287,7 +1287,7 @@ namespace FiftyOne.Pipeline.Engines.Services
 									result = AutoUpdateStatus.AUTO_UPDATE_HTTPS_ERR;
 									throw new DataUpdateException($"HTTP status code '{response.StatusCode}' " +
 										$"from data update service at " +
-										$"'{url}' for engine '{dataFile.EngineType?.Name}'", result); ;
+										$"'{url}' for engine '{dataFile.EngineType?.Name}'", result);
 							}
 						}
 					}

--- a/Tests/FiftyOne.Pipeline.Core.Tests/Data/ElementDataTests.cs
+++ b/Tests/FiftyOne.Pipeline.Core.Tests/Data/ElementDataTests.cs
@@ -238,7 +238,7 @@ namespace FiftyOne.Pipeline.Core.Tests.Data
             TestElementData data = new TestElementData(_pipeline.Object);
             Dictionary<string, object> newData = new Dictionary<string, object>();
             newData.Add("key", "value");
-            data.PopulateFromDictionary(newData);
+            data.PopulateFrom(newData);
 
             Assert.AreEqual("value", data["key"]);
         }
@@ -253,7 +253,7 @@ namespace FiftyOne.Pipeline.Core.Tests.Data
             TestElementData data = new TestElementData(_pipeline.Object);
             Dictionary<string, object> newData = new Dictionary<string, object>();
             newData.Add("result", "value");
-            data.PopulateFromDictionary(newData);
+            data.PopulateFrom(newData);
 
             Assert.AreEqual("value", data.Result);
         }
@@ -269,7 +269,7 @@ namespace FiftyOne.Pipeline.Core.Tests.Data
             Dictionary<string, object> newData = new Dictionary<string, object>();
             newData.Add("key1", "value1");
             newData.Add("key2", "value2");
-            data.PopulateFromDictionary(newData);
+            data.PopulateFrom(newData);
 
             Assert.AreEqual("value1", data["key1"]);
             Assert.AreEqual("value2", data["key2"]);
@@ -286,7 +286,7 @@ namespace FiftyOne.Pipeline.Core.Tests.Data
             Dictionary<string, object> newData = new Dictionary<string, object>();
             data["key1"] = "valueA";
             newData.Add("key1", "valueB");
-            data.PopulateFromDictionary(newData);
+            data.PopulateFrom(newData);
 
             Assert.AreEqual("valueB", data["key1"]);
         }

--- a/Tests/FiftyOne.Pipeline.Core.Tests/Data/EvidenceTests.cs
+++ b/Tests/FiftyOne.Pipeline.Core.Tests/Data/EvidenceTests.cs
@@ -85,7 +85,7 @@ namespace FiftyOne.Pipeline.Core.Tests.Data
         {
             const string newValue = "Value";
             var evidence = new Evidence(_logger.Object);
-            evidence.PopulateFromDictionary(map);
+            evidence.PopulateFrom(map);
             var first = map.First();
             evidence[first.Key] = newValue;
             Assert.AreEqual(evidence[first.Key], newValue);

--- a/Tests/FiftyOne.Pipeline.Core.Tests/Data/EvidenceTests.cs
+++ b/Tests/FiftyOne.Pipeline.Core.Tests/Data/EvidenceTests.cs
@@ -71,7 +71,7 @@ namespace FiftyOne.Pipeline.Core.Tests.Data
         public void Evidence_Maps(Dictionary<string, object> map)
         {
             var evidence = new Evidence(_logger.Object);
-            evidence.PopulateFromDictionary(map);
+            evidence.PopulateFrom(map);
             foreach(var expected in map)
             {
                 var actual = (StringValues)evidence[expected.Key];

--- a/Tests/FiftyOne.Pipeline.Engines.FiftyOne.Tests/FlowElements/SetHeadersElementTests.cs
+++ b/Tests/FiftyOne.Pipeline.Engines.FiftyOne.Tests/FlowElements/SetHeadersElementTests.cs
@@ -75,7 +75,7 @@ namespace FiftyOne.Pipeline.Engines.FiftyOne.Tests.FlowElements
             protected override void ProcessInternal(IFlowData data)
             {
                 var sourceData = data.GetOrAdd(ElementDataKey, p => CreateElementData(p));
-                sourceData.PopulateFromDictionary(_propertyNameValuesToReturn);
+                sourceData.PopulateFrom(_propertyNameValuesToReturn);
             }
 
             protected override void UnmanagedResourcesCleanup()


### PR DESCRIPTION
* addresses: #147 - `IData.PopulateFrom(IEnumerable)` was added the old `PopulateFromDictionary` method was marked as Obsolete
* also addresses #150 changed logger property visibility on JavaScriptBuilderElementBuilder