### PR TITLE
FIX: Properly Synchronize the SendAsync call

### DIFF
--- a/FiftyOne.Pipeline.CloudRequestEngine/FlowElements/CloudRequestEngine.cs
+++ b/FiftyOne.Pipeline.CloudRequestEngine/FlowElements/CloudRequestEngine.cs
@@ -36,6 +36,7 @@ using System.Globalization;
 using System.Linq;
 using System.Net.Http;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace FiftyOne.Pipeline.CloudRequestEngine.FlowElements
 {
@@ -925,7 +926,9 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.FlowElements
         {
             try
             {
-                return _httpClient.SendAsync(request).Result;
+                var task = Task.Run(() => _httpClient.SendAsync(request));
+                task.Wait();
+                return task.Result;
             }
             catch (AggregateException httpException)
             {


### PR DESCRIPTION
FIX: Properly Synchronize the SendAsync call using suggested method for netstandard. https://learn.microsoft.com/en-us/archive/blogs/jpsanders/asp-net-do-not-use-task-result-in-main-context