### PR TITLE
Change FlowElements to return ALL flow elements, including sub elements

### DIFF
--- a/FiftyOne.Pipeline.Core/Data/FlowData.cs
+++ b/FiftyOne.Pipeline.Core/Data/FlowData.cs
@@ -241,7 +241,8 @@ namespace FiftyOne.Pipeline.Core.Data
         }
 
         /// <summary>
-        /// Get all element data AspectPropertyValues that match the specified predicate
+        /// Get all element data AspectPropertyValues that match the 
+        /// specified predicate.
         /// </summary>
         /// <param name="predicate">
         /// If a property passed to this function returns true then it will

--- a/FiftyOne.Pipeline.Core/FlowElements/Pipeline.cs
+++ b/FiftyOne.Pipeline.Core/FlowElements/Pipeline.cs
@@ -196,10 +196,10 @@ namespace FiftyOne.Pipeline.Core.FlowElements
         /// Instances of ParallelElements are never included.
         /// </remarks>
         /// <remarks>
-        /// The double check lock could be removed if a 'Complete' or 
-        /// 'Finialize' method were added to the pipeline. This method 
-        /// would indicate that the pipeline would have completed all
-        /// set up tasks and FlowElements would be in a static state.
+        /// The double check lock could be removed if a 'Complete'
+        /// method were added to the pipeline. This method 
+        /// would indicate that the pipeline would have completed all of 
+        /// its set up tasks and FlowElements would be in a static state.
         /// </remarks>
         public IReadOnlyList<IFlowElement> FlowElements
         {
@@ -215,19 +215,9 @@ namespace FiftyOne.Pipeline.Core.FlowElements
                                 i is ParallelElements))
                             {
                                 var result = new List<IFlowElement>();
-                                foreach (var item in _flowElements)
+                                foreach (var element in _flowElements)
                                 {
-                                    if (item is ParallelElements)
-                                    {
-                                        result.AddRange(
-                                            (item as ParallelElements)
-                                            .FlowElements
-                                            .Select(e => e));
-                                    }
-                                    else
-                                    {
-                                        result.Add(item);
-                                    }
+                                    RecurseElements(result, element);
                                 }
                                 _allPublicFlowElements = 
                                     result.AsReadOnly();
@@ -242,8 +232,32 @@ namespace FiftyOne.Pipeline.Core.FlowElements
                 return _allPublicFlowElements;
             }
         }
+
         private readonly object _flowElementsLock = new object();
         private IReadOnlyList<IFlowElement> _allPublicFlowElements;
+
+        /// <summary>
+        /// Recursively add subelements to the result list.
+        /// </summary>
+        /// <param name="result"></param>
+        /// <param name="element"></param>
+        private void RecurseElements(
+            List<IFlowElement> result,
+            IFlowElement element)
+        {
+            if(element is ParallelElements == false)
+            {
+                result.Add(element);
+            }
+            else
+            {
+                foreach(var subelement in 
+                    (element as ParallelElements).FlowElements)
+                {
+                    RecurseElements(result, subelement);
+                }
+            }
+        }
 
         /// <summary>
         /// Get the dictionary of available properties for an

--- a/Tests/FiftyOne.Pipeline.Core.Tests/Data/FlowDataExtendedGetWhereTests.cs
+++ b/Tests/FiftyOne.Pipeline.Core.Tests/Data/FlowDataExtendedGetWhereTests.cs
@@ -278,7 +278,8 @@ public class FlowDataExtendedGetWhereTests
         .Setup(e => e.Process(It.IsAny<IFlowData>()))
         .Callback((IFlowData d) =>
         {
-            var tempdata = d.GetOrAdd(name, (p) => new TestElementData(p, new Dictionary<string, object>()
+            var tempdata = d.GetOrAdd(name, (p) => 
+            new TestElementData(p, new Dictionary<string, object>()
             {
                 { name, "value" }
             }));

--- a/Tests/FiftyOne.Pipeline.Core.Tests/Data/FlowDataExtendedGetWhereTests.cs
+++ b/Tests/FiftyOne.Pipeline.Core.Tests/Data/FlowDataExtendedGetWhereTests.cs
@@ -81,27 +81,31 @@ public class FlowDataExtendedGetWhereTests
         };
 
         // Assert
-        // assert that the amount of elements returned is the same 
+        // Assert that the amount of elements returned is the same 
         // as the amount added
         Assert.AreEqual(pipeline.FlowElements.Count, elements.Count());
 
-        // check the list of elements is equal. 
-        for (int i = 0; i < listOfTestedElements.Count - 1; i++)
+        // Collect all testing values
+        var testingValues = listOfTestedElements.Select(element =>
         {
-            // build a comparable value from the ingredients used to make
-            // the elements.
-            var elementName = listOfTestedElements[i].ElementDataKey;
-            var elementData = flowData
-                .Get(listOfTestedElements[i].ElementDataKey);
+            var elementName = element.ElementDataKey;
+            var elementData = flowData.Get(element.ElementDataKey);
             var elementDataValue = elementData
-                .AsDictionary()
-                .Keys
-                .First();
-            var testingValue = $"{elementName}.{elementDataValue}";
-            // Returned value from the tested method.
-            var getWhereValue = elements.ElementAt(i).Key;
-            Assert.AreEqual(testingValue, getWhereValue);
-        }
+            .AsDictionary()
+            .Keys
+            .First();
+            return $"{elementName}.{elementDataValue}";
+        }).ToList();
+
+        var elementKeys = elements.ToDictionary().Keys;
+
+        // Assert that the collected tested elements' keys are equal to
+        // the keys from elements
+        CollectionAssert.AreEquivalent(
+            testingValues.ToArray(),
+            elementKeys.ToArray(),
+            "The elements lists are not the same.");
+
     }
 
     /// <summary>
@@ -162,23 +166,26 @@ public class FlowDataExtendedGetWhereTests
         // as the amount added
         Assert.AreEqual(pipeline.FlowElements.Count, elements.Count());
 
-        // check the list of elements is equal. 
-        for (int i = 0; i < listOfTestedElements.Count - 1; i++)
+        // Collect all testing values
+        var testingValues = listOfTestedElements.Select(element =>
         {
-            // build a comparable value from the ingredients used to make
-            // the elements.
-            var elementName = listOfTestedElements[i].ElementDataKey;
-            var elementData = flowData
-                .Get(listOfTestedElements[i].ElementDataKey);
+            var elementName = element.ElementDataKey;
+            var elementData = flowData.Get(element.ElementDataKey);
             var elementDataValue = elementData
-                .AsDictionary()
-                .Keys
-                .First();
-            var testingValue = $"{elementName}.{elementDataValue}";
-            // Returned value from the tested method.
-            var getWhereValue = elements.ElementAt(i).Key;
-            Assert.AreEqual(testingValue, getWhereValue);
-        }
+            .AsDictionary()
+            .Keys
+            .First();
+            return $"{elementName}.{elementDataValue}";
+        }).ToList();
+
+        var elementKeys = elements.ToDictionary().Keys;
+
+        // Assert that the collected tested elements' keys are equal to
+        // the keys from elements
+        CollectionAssert.AreEquivalent(
+            testingValues.ToArray(),
+            elementKeys.ToArray(),
+            "The elements lists are not the same.");
     }
 
     /// <summary>
@@ -238,23 +245,26 @@ public class FlowDataExtendedGetWhereTests
         // as the amount added
         Assert.AreEqual(pipeline.FlowElements.Count, elements.Count());
 
-        // check the list of elements is equal. 
-        for (int i = 0; i < listOfTestedElements.Count - 1; i++)
+        // Collect all testing values
+        var testingValues = listOfTestedElements.Select(element =>
         {
-            // build a comparable value from the ingredients used to make
-            // the elements.
-            var elementName = listOfTestedElements[i].ElementDataKey;
-            var elementData = flowData
-                .Get(listOfTestedElements[i].ElementDataKey);
+            var elementName = element.ElementDataKey;
+            var elementData = flowData.Get(element.ElementDataKey);
             var elementDataValue = elementData
-                .AsDictionary()
-                .Keys
-                .First();
-            var testingValue = $"{elementName}.{elementDataValue}";
-            // Returned value from the tested method.
-            var getWhereValue = elements.ElementAt(i).Key;
-            Assert.AreEqual(testingValue, getWhereValue);
-        }
+            .AsDictionary()
+            .Keys
+            .First();
+            return $"{elementName}.{elementDataValue}";
+        }).ToList();
+
+        var elementKeys = elements.ToDictionary().Keys;
+
+        // Assert that the collected tested elements' keys are equal to
+        // the keys from elements
+        CollectionAssert.AreEquivalent(
+            testingValues.ToArray(),
+            elementKeys.ToArray(),
+            "The elements lists are not the same.");
     }
     
     /// <summary>
@@ -331,10 +341,8 @@ public class FlowDataExtendedGetWhereTests
         // assert that the amount of elements returned is the same 
         // as the amount added
         Assert.AreEqual(5, elements.Count);
-        foreach(var element in listOfTestedElements)
-        {
-            Assert.IsTrue(elements.Contains(element));
-        }
+        CollectionAssert.AreEquivalent(listOfTestedElements,
+            elements.ToArray());
     }
 
     /// <summary>

--- a/Tests/FiftyOne.Pipeline.Core.Tests/Data/FlowDataTests.cs
+++ b/Tests/FiftyOne.Pipeline.Core.Tests/Data/FlowDataTests.cs
@@ -41,7 +41,6 @@ namespace FiftyOne.Pipeline.Core.Tests.Data
     [TestClass]
     public class FlowDataTests
     {
-
         private Mock<IPipelineInternal> _pipeline;
         private Mock<ILogger<FlowData>> _logger;
         private FlowData _flowData;


### PR DESCRIPTION
Change FlowElements to return ALL flow elements, including sub elements. 

Before, sub elements that are part of a parallel element would not be returned as the Parallel element would not be unpacked and will not contain an element data key. 
Now, unpack the parallel elements to create the full list.

Add extended test methods for the GetWhere method to ensure that all element data for all elements (including parallel elements is returned). These have been added to a separate file/test class as the set up for these tests differs from the setup for the other FlowData tests.