### PR TITLE
temporarily set devtools protocol version to 127 for selenium tests

### DIFF
--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/FiftyOne.Pipeline.JavaScriptBuilderElementTests.csproj
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/FiftyOne.Pipeline.JavaScriptBuilderElementTests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
     <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
-    <PackageReference Include="Selenium.WebDriver" Version="4.23.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.28.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/JavaScriptBuilderElementTestsBase.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/JavaScriptBuilderElementTestsBase.cs
@@ -59,6 +59,10 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
             chromeOptions.AddArgument("--headless");
             try
             {
+                var options = new ChromeOptions();
+
+                // Set the desired DevTools protocol version
+                options.AddAdditionalOption("devtoolsProtocolVersion", "127"); 
                 Driver = new ChromeDriver(chromeOptions);
             }
             catch (WebDriverException)

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/JavaScriptBuilderElementTestsBase.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/JavaScriptBuilderElementTestsBase.cs
@@ -61,7 +61,9 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
             {
                 var options = new ChromeOptions();
 
-                // Set the desired DevTools protocol version
+                // Temporarily set the devtools version to 127 as 
+                // Webdriver package is not quite ready for Chrome 132 
+                // that was recently updated on some runners on CI
                 options.AddAdditionalOption("devtoolsProtocolVersion", "127"); 
                 Driver = new ChromeDriver(chromeOptions);
             }


### PR DESCRIPTION
as Chrome has updated to 132 on some gh runners and Webdriver package is not exactly ready for this - hence the explicit protocol version is temporarily set - can be upgraded later. 