### PR TITLE
FEAT: Add Parsing and Setting for Enum.Types in BuildFromConfiguration

### DIFF
--- a/FiftyOne.Pipeline.Core/FlowElements/PipelineBuilder.cs
+++ b/FiftyOne.Pipeline.Core/FlowElements/PipelineBuilder.cs
@@ -178,7 +178,7 @@ namespace FiftyOne.Pipeline.Core.FlowElements
                     this,
                     "pipeline");
             }
-            // Paralell foreach aggregates the exceptions.
+            // Parallel foreach aggregates the exceptions.
             catch (AggregateException ex)
             {
                 if(ex.InnerExceptions.Count > 1)
@@ -396,6 +396,7 @@ namespace FiftyOne.Pipeline.Core.FlowElements
             var buildMethod = possibleBuildMethods.Single();
             var caseInsensitiveParameters = elementOptions.BuildParameters
                 .ToDictionary(d => d.Key.ToUpperInvariant(), d => d.Value);
+            var test = buildMethod.GetParameters();
             foreach (var parameterInfo in buildMethod.GetParameters())
             {
                 var paramType = parameterInfo.ParameterType;
@@ -427,7 +428,7 @@ namespace FiftyOne.Pipeline.Core.FlowElements
                     $"'IFlowElement' for {elementLocation}");
             }
 
-            elements.TryAdd(elementIndex,element);
+            elements.TryAdd(elementIndex, element);
         }
 
         /// <summary>
@@ -946,7 +947,6 @@ namespace FiftyOne.Pipeline.Core.FlowElements
         private static object ParseToType(Type targetType, string value, string errorTextPrefix)
         {
             object result = null;
-
             if (typeof(IList<string>).IsAssignableFrom(targetType) ||
                 targetType.IsArray)
             {
@@ -975,6 +975,23 @@ namespace FiftyOne.Pipeline.Core.FlowElements
                         $"example a list of text values containing 6 inches " +
                         $"and 12 inches would look like this: " +
                         $"\"6\"\"\",\"12\"\"\")", ex);
+                }
+            }
+            else if (targetType.IsEnum)
+            {
+                try
+                {
+                    result = Enum.Parse(targetType, value, true);
+                }
+                catch(ArgumentException ex)
+                {
+                    throw new PipelineConfigurationException(
+                        $"{errorTextPrefix}. Failed to parse enum " +
+                        $"value '{value}'. " +
+                        $"Valid values are: " +
+                        $"{string.Join(", ", Enum.GetNames(targetType))}",
+                        ex
+                    );
                 }
             }
             else

--- a/Tests/FiftyOne.Pipeline.Core.Tests/FlowElements/PipelineBuilderTests.cs
+++ b/Tests/FiftyOne.Pipeline.Core.Tests/FlowElements/PipelineBuilderTests.cs
@@ -27,12 +27,15 @@ using FiftyOne.Pipeline.Core.FlowElements;
 using FiftyOne.Pipeline.Core.Services;
 using FiftyOne.Pipeline.Core.Tests.HelperClasses;
 using FiftyOne.Pipeline.Core.Tests.HelperClasses.CompositeConfig;
+using FiftyOne.Pipeline.Engines;
 using FiftyOne.Pipeline.Engines.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using System.Xml.Linq;
 
@@ -125,7 +128,7 @@ namespace FiftyOne.Pipeline.Core.Tests.FlowElements
             };
             element.BuildParameters.Add("multiple", "8");
 
-            PipelineOptions opts = new PipelineOptions();
+            PipelineOptions opts = new();
             opts.Elements = new List<ElementOptions>
             {
                 element
@@ -502,6 +505,34 @@ namespace FiftyOne.Pipeline.Core.Tests.FlowElements
             _maxErrors = 1;
 
             VerifyListSplitterElementPipeline(opts, SplitOption.Comma);
+        }  
+        
+        /// <summary>
+        /// Test that setting an Enum type is properly parsed and set by 
+        /// BuildFromConfiguration. 
+        /// </summary>
+        [TestMethod]
+        public void PipelineBuilder_BuildFromConfiguration_EnumType()
+        {
+            var element = new ElementOptions()
+            {
+                BuilderName = "EnumPerfProfile"
+            };
+            element.BuildParameters.Add("SetPerformanceProfile",
+                PerformanceProfiles.HighPerformance);
+
+            // Create the configuration object.
+            PipelineOptions opts = new();
+            opts.Elements =
+            [
+                element
+            ];
+
+            var pipeline = _builder.BuildFromConfiguration(opts);
+            var retreivedElement = pipeline.GetElement<EnumPerfProfileElement>();
+
+            Assert.IsTrue(retreivedElement.PerfProfile ==
+                PerformanceProfiles.HighPerformance);
         }
 
 
@@ -1021,6 +1052,6 @@ namespace FiftyOne.Pipeline.Core.Tests.FlowElements
                 var elementData = flowData.GetFromElement(element);
                 Assert.AreEqual(40, elementData.Result);
             }
-        }
+        }   
     }
 }

--- a/Tests/FiftyOne.Pipeline.Core.Tests/FlowElements/PipelineBuilderTests.cs
+++ b/Tests/FiftyOne.Pipeline.Core.Tests/FlowElements/PipelineBuilderTests.cs
@@ -512,14 +512,19 @@ namespace FiftyOne.Pipeline.Core.Tests.FlowElements
         /// BuildFromConfiguration. 
         /// </summary>
         [TestMethod]
-        public void PipelineBuilder_BuildFromConfiguration_EnumType()
+        [DataRow("HighPerformance", PerformanceProfiles.HighPerformance)]
+        [DataRow("Balanced", PerformanceProfiles.Balanced)]
+        [DataRow(PerformanceProfiles.MaxPerformance, PerformanceProfiles.MaxPerformance)]
+        public void PipelineBuilder_BuildFromConfiguration_EnumType(
+            object enumValue,
+            PerformanceProfiles expected)
         {
             var element = new ElementOptions()
             {
                 BuilderName = "EnumPerfProfile"
             };
             element.BuildParameters.Add("SetPerformanceProfile",
-                PerformanceProfiles.HighPerformance);
+                enumValue);
 
             // Create the configuration object.
             PipelineOptions opts = new();
@@ -531,8 +536,7 @@ namespace FiftyOne.Pipeline.Core.Tests.FlowElements
             var pipeline = _builder.BuildFromConfiguration(opts);
             var retreivedElement = pipeline.GetElement<EnumPerfProfileElement>();
 
-            Assert.IsTrue(retreivedElement.PerfProfile ==
-                PerformanceProfiles.HighPerformance);
+            Assert.IsTrue(retreivedElement.PerfProfile == expected);
         }
 
 

--- a/Tests/FiftyOne.Pipeline.Core.Tests/HelperClasses/EnumPerfProfileElement.cs
+++ b/Tests/FiftyOne.Pipeline.Core.Tests/HelperClasses/EnumPerfProfileElement.cs
@@ -1,0 +1,78 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2023 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+using FiftyOne.Pipeline.Core.Data;
+using FiftyOne.Pipeline.Core.FlowElements;
+using FiftyOne.Pipeline.Engines;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Collections.Generic;
+
+namespace FiftyOne.Pipeline.Core.Tests.HelperClasses
+{
+    /// <summary>
+    /// Test element that has an Enum property that can be set in configuration
+    /// </summary>
+    public class EnumPerfProfileElement : FlowElementBase<TestElementData, IElementPropertyMetaData>
+    {
+        public override string ElementDataKey => "EnumPerfProfile";
+
+        public List<string> EvidenceKeys = new List<string>()
+        {
+            "value"
+        };
+        private EvidenceKeyFilterWhitelist _evidenceKeyFilter;
+
+        public override IEvidenceKeyFilter EvidenceKeyFilter => _evidenceKeyFilter;
+
+        public override IList<IElementPropertyMetaData> Properties => new List<IElementPropertyMetaData>();
+
+        // public so we can assert its value.
+        public PerformanceProfiles PerfProfile => _perfProfile;
+        private PerformanceProfiles _perfProfile;
+
+        public EnumPerfProfileElement(PerformanceProfiles profile) :
+            base(new Mock<ILogger<EnumPerfProfileElement>>().Object)
+        {
+            _perfProfile = profile;
+            _evidenceKeyFilter = new EvidenceKeyFilterWhitelist(EvidenceKeys);
+        }
+
+        protected override void ProcessInternal(IFlowData data)
+        {
+            TestElementData elementData = data.GetOrAdd(
+                ElementDataKeyTyped,
+                (p) => new TestElementData(p));
+            int value = (int)data.GetEvidence()[EvidenceKeys[0]];
+            elementData.Result = value;
+        }
+
+        protected override void ManagedResourcesCleanup()
+        {
+        }
+
+        protected override void UnmanagedResourcesCleanup()
+        {
+        }
+    }
+
+}

--- a/Tests/FiftyOne.Pipeline.Core.Tests/HelperClasses/EnumPerfProfileElementBuilder.cs
+++ b/Tests/FiftyOne.Pipeline.Core.Tests/HelperClasses/EnumPerfProfileElementBuilder.cs
@@ -1,0 +1,58 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2023 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+using FiftyOne.Pipeline.Core.Attributes;
+using FiftyOne.Pipeline.Core.FlowElements;
+using FiftyOne.Pipeline.Engines;
+
+namespace FiftyOne.Pipeline.Core.Tests.HelperClasses
+{
+    /// <summary>
+    /// The builder to use when creating <see cref="EnumPerfProfileElement"/>
+    /// </summary>
+    [AlternateName("EnumPerfProfile")]
+    public class EnumPerfProfileElementBuilder
+    {
+
+        /// <summary>
+        /// The performance profile to use for the device detection engine.
+        /// </summary>
+        private PerformanceProfiles _performanceProfile;
+
+        public EnumPerfProfileElementBuilder SetPerformanceProfile(
+            PerformanceProfiles profile)
+        {
+            _performanceProfile = profile;
+            return this;
+        }
+
+        /// <summary>
+        /// The builder has one parameter and it is mandatory.
+        /// </summary>
+        /// <param name="multiple"></param>
+        /// <returns></returns>
+        public IFlowElement Build()
+        {
+            return new EnumPerfProfileElement(_performanceProfile);
+        }
+    }
+}


### PR DESCRIPTION
Add a test and a test element for a configured element that has an Enum type.