### PR TITLE
Add new shared types

### DIFF
--- a/FiftyOne.Pipeline.Core/Data/IWeightedValue.cs
+++ b/FiftyOne.Pipeline.Core/Data/IWeightedValue.cs
@@ -1,0 +1,61 @@
+﻿/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2025 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+namespace FiftyOne.Pipeline.Core.Data
+{
+    /// <summary>
+    /// The value with associated weighting.
+    /// </summary>
+    /// <typeparam name="T">
+    /// Type of value stored within.
+    /// </typeparam>
+    public interface IWeightedValue<T>
+    {
+        /// <summary>
+        /// "Integer" weight factor. 
+        /// </summary>
+        ushort RawWeighting { get; }
+        
+        /// <summary>
+        /// A specific value stored within.
+        /// </summary>
+        T Value { get; }
+    }
+
+    /// <summary>
+    /// Extensions for <see cref="IWeightedValue{T}"/>.
+    /// </summary>
+    public static class WeightedValueExtensions
+    {
+        /// <summary>
+        /// Recalculates <see cref="IWeightedValue{T}.RawWeighting"/>
+        /// into a floating point value in range (0~1).
+        /// </summary>
+        /// <param name="value">Value to get weighting from.</param>
+        /// <typeparam name="T">Type of stored value.</typeparam>
+        /// <returns>Weighting as (0~1) multiplier.</returns>
+        public static float Weighting<T>(this IWeightedValue<T> value)
+        {
+            return value.RawWeighting / (float)ushort.MaxValue;
+        }
+    }
+}

--- a/FiftyOne.Pipeline.Core/Data/WeightedValue.cs
+++ b/FiftyOne.Pipeline.Core/Data/WeightedValue.cs
@@ -1,0 +1,69 @@
+﻿/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2025 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace FiftyOne.Pipeline.Core.Data
+{
+    /// <summary>
+    /// The value with associated weighting.
+    /// </summary>
+    /// <typeparam name="T">
+    /// Type of value stored within.
+    /// </typeparam>
+    public class WeightedValue<T> : IWeightedValue<T>
+    {
+        /// <summary>
+        /// "Integer" weight factor. 
+        /// </summary>
+        public ushort RawWeighting { get; }
+        
+        /// <summary>
+        /// A specific value stored within.
+        /// </summary>
+        public T Value { get; }
+
+        /// <summary>
+        /// Designated constructor.
+        /// </summary>
+        /// <param name="rawWeighting">"Integer" weight factor.</param>
+        /// <param name="value">A specific value to store within.</param>
+        public WeightedValue(ushort rawWeighting, T value)
+        {
+            RawWeighting = rawWeighting;
+            Value = value;
+        }
+
+        /// <inheritdoc cref="object.GetHashCode"/>
+        public override int GetHashCode()
+        {
+            return RawWeighting.GetHashCode() ^ RuntimeHelpers.GetHashCode(Value);
+        }
+
+        /// <inheritdoc cref="object.ToString"/>
+        public override string ToString()
+        {
+            return $"({GetType().Name} {RawWeighting}x  {Value})";
+        }
+    }
+}

--- a/FiftyOne.Pipeline.Core/Data/WeightedValue.cs
+++ b/FiftyOne.Pipeline.Core/Data/WeightedValue.cs
@@ -20,7 +20,6 @@
  * such notice(s) shall fulfill the requirements of that article.
  * ********************************************************************* */
 
-using System;
 using System.Runtime.CompilerServices;
 
 namespace FiftyOne.Pipeline.Core.Data

--- a/FiftyOne.Pipeline.Core/Data/WktString.cs
+++ b/FiftyOne.Pipeline.Core/Data/WktString.cs
@@ -1,0 +1,167 @@
+﻿/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2025 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+using System;
+
+namespace FiftyOne.Pipeline.Core.Data
+{
+    /// <summary>
+    /// <para>
+    /// Well-known text representation of geometry.
+    /// </para><para>
+    /// See
+    /// <see href="https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry"/>
+    /// </para>
+    /// </summary>
+    public struct WktString : IEquatable<WktString>, IEquatable<string>
+    {
+        /// <summary>
+        /// <para>
+        /// Value that adheres to the OGC 06-103r4 standard.
+        /// </para><para>
+        /// See
+        /// <see href="https://www.ogc.org/publications/standard/sfa/"/>
+        /// </para>
+        /// </summary>
+        /// <example>
+        /// <para><c>POINT(2 4)</c></para>
+        /// <para><c>POLYGON((10 10,10 20,20 20,20 15,10 10))</c></para>
+        /// </example>
+        public string Value { get; }
+
+        /// <summary>
+        /// Designated constructor.
+        /// </summary>
+        /// <param name="value">Internal text value.</param>
+        public WktString(string value)
+        {
+            Value = value;
+        }
+
+        /// <summary>
+        /// Check if the specified value is equal to this instance.
+        /// </summary>
+        /// <param name="other">
+        /// The value to check for equality
+        /// </param>
+        /// <returns>
+        /// True if the values are equal, false otherwise
+        /// </returns>
+        public bool Equals(WktString other)
+        {
+            return Value == other.Value; 
+        }
+
+        /// <summary>
+        /// Check if the specified value is equal to this instance.
+        /// </summary>
+        /// <param name="other">
+        /// The value to check for equality
+        /// </param>
+        /// <returns>
+        /// True if the values are equal, false otherwise
+        /// </returns>
+        public bool Equals(string other)
+        {
+            return Value == other;
+        }
+
+        /// <summary>
+        /// Check if the specified value is equal to this instance.
+        /// </summary>
+        /// <param name="obj">
+        /// The value to check for equality
+        /// </param>
+        /// <returns>
+        /// True if the values are equal, false otherwise
+        /// </returns>
+        public override bool Equals(object obj)
+        {
+            return obj is WktString otherWkt && Equals(otherWkt)
+                   || obj is string otherString && Equals(otherString);
+        }
+
+        /// <summary>
+        /// Get a hash code for this instance
+        /// </summary>
+        /// <remarks>
+        /// The hash code is taken directly from the string representation
+        /// of this instance.
+        /// </remarks>
+        /// <returns>
+        /// The hash code for this instance
+        /// </returns>
+        public override int GetHashCode()
+        {
+            return Value.GetHashCode();
+        }
+
+        /// <summary>
+        /// Get the string representation of this instance.
+        /// </summary>
+        /// <returns>
+        /// The string representation of this instance.
+        /// </returns>
+        public override string ToString()
+        {
+            return Value;
+        }
+        
+        /// <summary>
+        /// Operator overload
+        /// </summary>
+        /// <param name="left">Left-hand side of comparison</param>
+        /// <param name="right">Right-hand side of comparison</param>
+        /// <returns>true/false</returns>
+        public static bool operator==(WktString left, WktString right)
+            => left.Equals(right);
+        
+        /// <summary>
+        /// Operator overload
+        /// </summary>
+        /// <param name="left">Left-hand side of comparison</param>
+        /// <param name="right">Right-hand side of comparison</param>
+        /// <returns>true/false</returns>
+        public static bool operator!=(WktString left, WktString right)
+            => !left.Equals(right);
+        
+        /// <summary>
+        /// Implicit conversion
+        /// from <see cref="WktString"/>
+        /// to <see cref="string"/>.
+        /// </summary>
+        /// <param name="wktString">WKT string</param>
+        /// <returns>The string</returns>
+        public static implicit operator string(WktString wktString)
+            => wktString.Value;
+        
+        /// <summary>
+        /// Implicit conversion
+        /// from <see cref="string"/>
+        /// to <see cref="WktString"/>.
+        /// </summary>
+        /// <param name="wktString">"normal" string</param>
+        /// <returns>The WKT String</returns>
+        public static implicit operator WktString(string wktString)
+            => new WktString(wktString);
+    }
+}

--- a/FiftyOne.Pipeline.Core/Utils/TypeNameHelper.cs
+++ b/FiftyOne.Pipeline.Core/Utils/TypeNameHelper.cs
@@ -1,0 +1,86 @@
+﻿/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2025 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+using System;
+using System.Reflection;
+using System.Text;
+
+namespace FiftyOne.Pipeline.Core.Utils
+{
+    /// <summary>
+    /// Provides helper methods to get
+    /// a human-readable description
+    /// of <see cref="Type"/>s
+    /// including the names
+    /// of nested type parameters.
+    /// </summary>
+    public static class TypeNameHelper
+    {
+        /// <summary>
+        /// <para>
+        /// Appends type name and generic parameter type names.
+        /// </para><para>
+        /// Recursively includes the descriptions of generic parameters.
+        /// </para>
+        /// </summary>
+        /// <param name="type">Type to describe.</param>
+        /// <param name="typeNameBuilder">Builder to add description to.</param>
+        public static void AppendPrettyTypeName(StringBuilder typeNameBuilder, Type type)
+        {
+            if (!type.IsGenericType)
+            {
+                typeNameBuilder.Append(type.Name);
+                return;
+            }
+
+            var typeName = type.Name;
+            var genericTypeName = typeName.Substring(0, typeName.IndexOf('`'));
+            typeNameBuilder.Append(genericTypeName);
+            var genericArguments = type.GetGenericArguments();
+            typeNameBuilder.Append('<');
+            for (int i = 0; i < genericArguments.Length; i++)
+            {
+                if (i > 0)
+                    typeNameBuilder.Append(", ");
+                AppendPrettyTypeName(typeNameBuilder, genericArguments[i]);
+            }
+            typeNameBuilder.Append('>');
+        }
+
+        /// <summary>
+        /// <para>
+        /// An improved version of <see cref="Type"/>.<see cref="MemberInfo.Name"/>.
+        /// </para><para>
+        /// Recursively includes the descriptions of generic parameters.
+        /// </para>
+        /// </summary>
+        /// <param name="type"><see cref="Type"/> to describe.</param>
+        /// <returns>Type description</returns>
+        /// <example><c>IAspectPropertyValue&lt;String&gt;</c></example>
+        public static string GetPrettyTypeName(Type type)
+        {
+            var typeNameBuilder = new StringBuilder();
+            AppendPrettyTypeName(typeNameBuilder, type);
+            return typeNameBuilder.ToString();
+        }
+    }
+}

--- a/Tests/FiftyOne.Pipeline.Core.Tests/Data/WeightedValueTests.cs
+++ b/Tests/FiftyOne.Pipeline.Core.Tests/Data/WeightedValueTests.cs
@@ -1,0 +1,53 @@
+﻿/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2025 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+using FiftyOne.Pipeline.Core.Data;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace FiftyOne.Pipeline.Core.Tests.Data;
+
+[TestClass]
+public class WeightedValueTests
+{
+    [TestMethod]
+    public void WeightedValue_Weighting_1()
+    {
+        IWeightedValue<string> value = new WeightedValue<string>(
+            ushort.MaxValue, "the only value");
+        Assert.AreEqual("the only value", value.Value);
+        Assert.AreEqual(1, value.Weighting());
+    }
+    
+    [TestMethod]
+    public void WeightedValue_Weighting_05()
+    {
+        WeightedValue<int>[] values =
+        {
+            new(ushort.MaxValue / 2 + 1, 5),
+            new(ushort.MaxValue / 2, 13),
+        };
+        Assert.AreEqual(5, values[0].Value);
+        Assert.AreEqual(13, values[1].Value);
+        Assert.AreEqual(0.5f + 0.5f / ushort.MaxValue, values[0].Weighting());
+        Assert.AreEqual(0.5f - 0.5f / ushort.MaxValue, values[1].Weighting());
+    }
+}

--- a/Tests/FiftyOne.Pipeline.Core.Tests/Data/WktStringTests.cs
+++ b/Tests/FiftyOne.Pipeline.Core.Tests/Data/WktStringTests.cs
@@ -1,0 +1,152 @@
+﻿/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2025 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+using System;
+using System.Collections.Generic;
+using FiftyOne.Pipeline.Core.Data;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace FiftyOne.Pipeline.Core.Tests.Data;
+
+[TestClass]
+public class WktStringTests
+{
+    private const string WktPoint = "POINT(2 4)";
+    private const string WktPolygon = "POLYGON((10 10,10 20,20 20,20 15,10 10))";
+
+    private static IEnumerable<string[]> RawStrings => new[]
+    {
+        new[] { WktPoint, },
+        new[] { WktPolygon, },
+    };
+    
+    [DataTestMethod]
+    [DynamicData(nameof(RawStrings))]
+    public void WktString_Value_NewImplicit(string rawString)
+    {
+        WktString wktString = rawString;
+        Assert.AreEqual(rawString, wktString.Value);
+    }
+    
+    [DataTestMethod]
+    [DynamicData(nameof(RawStrings))]
+    public void WktString_Value_NewExplicit(string rawString)
+    {
+        WktString wktString = new WktString(rawString);
+        Assert.AreEqual(rawString, wktString.Value);
+    }
+    
+    [DataTestMethod]
+    [DynamicData(nameof(RawStrings))]
+    public void WktString_GetHashCode(string rawString)
+    {
+        WktString wktString = rawString;
+        Assert.AreEqual(rawString.GetHashCode(), wktString.GetHashCode());
+    }
+    
+    [DataTestMethod]
+    [DynamicData(nameof(RawStrings))]
+    public void WktString_ToString_Method(string rawString)
+    {
+        WktString wktString = rawString;
+        string theString = wktString.ToString();
+        Assert.AreEqual(rawString, theString);
+    }
+    
+    [DataTestMethod]
+    [DynamicData(nameof(RawStrings))]
+    public void WktString_ToString_Implicit(string rawString)
+    {
+        WktString wktString = rawString;
+        string theString = wktString;
+        Assert.AreEqual(rawString, theString);
+    }
+    
+    [DataTestMethod]
+    [DynamicData(nameof(RawStrings))]
+    public void WktString_ToString_Equals_WktExplicit(string rawString)
+    {
+        WktString wktString = rawString;
+        WktString wktString2 = rawString;
+        Assert.IsTrue(wktString.Equals(wktString2));
+        Assert.IsTrue(wktString2.Equals(wktString));
+    }
+    
+    [DataTestMethod]
+    [DynamicData(nameof(RawStrings))]
+    public void WktString_ToString_Equals_StringExplicit(string rawString)
+    {
+        WktString wktString = rawString;
+        Assert.IsTrue(wktString.Equals(rawString));
+    }
+
+    private static IEnumerable<object[]> EqualityTestData =>
+    [
+        [WktPoint, typeof(string), true],
+        [new WktString(WktPoint), typeof(WktString), true],
+        [WktPolygon, typeof(string), false],
+        [new WktString(WktPolygon), typeof(WktString), false],
+    ];
+    
+    [DataTestMethod]
+    [DynamicData(nameof(EqualityTestData))]
+    public void WktString_ToString_Equals_ObjectMethod(object obj, Type type, bool expected)
+    {
+        WktString wktString = WktPoint;
+        Assert.AreEqual(type, obj.GetType());
+        Assert.AreEqual(expected, wktString.Equals(obj));
+    }
+    
+    [TestMethod]
+    public void WktString_ToString_Equals_WktOperator()
+    {
+        WktString wktString = WktPoint;
+        WktString wktString2 = WktPoint;
+        WktString wktString3 = WktPolygon;
+        
+        Assert.IsTrue(wktString == wktString2);
+        Assert.IsTrue(wktString2 == wktString);
+        Assert.IsFalse(wktString != wktString2);
+        Assert.IsFalse(wktString2 != wktString);
+        
+        Assert.IsFalse(wktString == wktString3);
+        Assert.IsFalse(wktString3 == wktString);
+        Assert.IsTrue(wktString != wktString3);
+        Assert.IsTrue(wktString3 != wktString);
+    }
+    
+    [TestMethod]
+    public void WktString_ToString_Equals_StringOperator()
+    {
+        WktString wktString = WktPoint;
+        
+        Assert.IsTrue(wktString == WktPoint);
+        Assert.IsTrue(WktPoint == wktString);
+        Assert.IsFalse(wktString != WktPoint);
+        Assert.IsFalse(WktPoint != wktString);
+        
+        Assert.IsFalse(wktString == WktPolygon);
+        Assert.IsFalse(WktPolygon == wktString);
+        Assert.IsTrue(wktString != WktPolygon);
+        Assert.IsTrue(WktPolygon != wktString);
+    }
+}

--- a/Tests/FiftyOne.Pipeline.Core.Tests/Utils/TypeNameHelperTest.cs
+++ b/Tests/FiftyOne.Pipeline.Core.Tests/Utils/TypeNameHelperTest.cs
@@ -1,0 +1,113 @@
+﻿/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2025 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using FiftyOne.Pipeline.Engines.Data;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using static FiftyOne.Pipeline.Core.Utils.TypeNameHelper;
+
+namespace FiftyOne.Pipeline.Core.Tests.Utils;
+
+[TestClass]
+public class TypeNameHelperTest
+{
+    [TestMethod]
+    public void TypeNameHelper_GetPrettyTypeName_Int()
+    {
+        Type t = typeof(int);
+        Assert.AreEqual("Int32", GetPrettyTypeName(t));
+        Assert.AreEqual(t.Name, GetPrettyTypeName(t));
+    }
+    
+    [TestMethod]
+    public void TypeNameHelper_GetPrettyTypeName_String()
+    {
+        Type t = typeof(string);
+        Assert.AreEqual("String", GetPrettyTypeName(t));
+        Assert.AreEqual(t.Name, GetPrettyTypeName(t));
+    }
+    
+    [TestMethod]
+    public void TypeNameHelper_GetPrettyTypeName_IEnumerable()
+    {
+        Type t = typeof(IEnumerable);
+        Assert.AreEqual("IEnumerable", GetPrettyTypeName(t));
+        Assert.AreEqual(t.Name, GetPrettyTypeName(t));
+    }
+    
+    [TestMethod]
+    public void TypeNameHelper_GetPrettyTypeName_IEnumerable_String()
+    {
+        Type t = typeof(IEnumerable<string>);
+        Assert.AreEqual("IEnumerable<String>", GetPrettyTypeName(t));
+        Assert.AreEqual($"{nameof(IEnumerable<string>)}<{typeof(string).Name}>", GetPrettyTypeName(t));
+    }
+    
+    [TestMethod]
+    public void TypeNameHelper_GetPrettyTypeName_IDictionary_IReadOnlyList()
+    {
+        Type t = typeof(IDictionary<float, IReadOnlyList<IDisposable>>);
+        Assert.AreEqual("IDictionary<Single, IReadOnlyList<IDisposable>>", GetPrettyTypeName(t));
+        Assert.AreEqual(
+            (nameof(IDictionary<float, IReadOnlyList<IDisposable>>)
+             + "<"
+             + typeof(float).Name
+             + ", "
+             + nameof(IReadOnlyList<IDisposable>)
+             + "<"
+             + nameof(IDisposable)
+             + ">>"),
+            GetPrettyTypeName(t));
+    }
+    
+    [TestMethod]
+    public void TypeNameHelper_GetPrettyTypeName_IAspectPropertyValue_String()
+    {
+        Type t = typeof(IAspectPropertyValue<string>);
+        Assert.AreEqual(
+            (nameof(IAspectPropertyValue<string>)
+             + "<"
+             + typeof(string).Name
+             + ">"),
+            GetPrettyTypeName(t));
+    }
+    
+    [TestMethod]
+    public void TypeNameHelper_GetPrettyTypeName_Func3()
+    {
+        Type t = typeof(
+            Func<
+                KeyValuePair<string, float>,
+                IDictionary<
+                    IEquatable<string>,
+                    IEnumerable<IAspectPropertyValue<IReadOnlyList<int>>>
+                >,
+                double
+            >);
+        Assert.AreEqual(
+            ("Func<KeyValuePair<String, Single>, IDictionary<IEquatable<String>, "
+             + $"IEnumerable<{nameof(IAspectPropertyValue)}<IReadOnlyList<Int32>>>>, Double>"),
+            GetPrettyTypeName(t));
+    }
+}

--- a/Tests/FiftyOne.Pipeline.Core.Tests/Utils/TypeNameHelperTests.cs
+++ b/Tests/FiftyOne.Pipeline.Core.Tests/Utils/TypeNameHelperTests.cs
@@ -30,7 +30,7 @@ using static FiftyOne.Pipeline.Core.Utils.TypeNameHelper;
 namespace FiftyOne.Pipeline.Core.Tests.Utils;
 
 [TestClass]
-public class TypeNameHelperTest
+public class TypeNameHelperTests
 {
     [TestMethod]
     public void TypeNameHelper_GetPrettyTypeName_Int()


### PR DESCRIPTION
### Changes

- Add `TypeNameHelper` and tests.
  - As a replacement for [MemberInfo.Name](https://learn.microsoft.com/en-us/dotnet/api/system.reflection.memberinfo.name?view=netstandard-2.0#system-reflection-memberinfo-name) (inherited by [Type](https://learn.microsoft.com/en-us/dotnet/api/system.type?view=netstandard-2.0))
  - Respects and describes generic parameters, e.g. `IAspectPropertyValue<String>` vs ``IAspectPropertyValue`1``
- Add `WeightedValue` and tests.
  - https://github.com/51Degrees/specifications/blob/feature/ip/pipeline-specification/features/weighted-values.md
  - https://github.com/51Degrees/specifications/blob/feature/ip/ip-intelligence-specification/data-model.md#property-details
- Add `WktString` and tests.
  - https://github.com/51Degrees/specifications/blob/feature/ip/ip-intelligence-specification/data-model.md#wkt-type

### Test runs

- ✅ https://github.com/postindustria-tech/pipeline-dotnet/actions/runs/13122623550