### PR TITLE
ci: remove macos Debug build variant from options.json and build Release on macos-latest

### DIFF
--- a/ci/options.json
+++ b/ci/options.json
@@ -45,14 +45,14 @@
         "BuildMethod": "dotnet"
     },
     {
-        "Image": "macos-13",
+        "Image": "macos-latest",
         "Name": "macos_AnyCPU_Release",
         "Configuration": "CoreRelease",
         "Arch": "Any CPU",
         "BuildMethod": "dotnet",
     },
     {
-        "Image": "macos-13",
+        "Image": "macos-latest",
         "Name": "macos_AnyCPU_Debug",
         "Configuration": "CoreDebug",
         "Arch": "Any CPU",

--- a/ci/options.json
+++ b/ci/options.json
@@ -50,12 +50,5 @@
         "Configuration": "CoreRelease",
         "Arch": "Any CPU",
         "BuildMethod": "dotnet",
-    },
-    {
-        "Image": "macos-latest",
-        "Name": "macos_AnyCPU_Debug",
-        "Configuration": "CoreDebug",
-        "Arch": "Any CPU",
-        "BuildMethod": "dotnet"
     }
 ]


### PR DESCRIPTION
Motivation: improve stability of the builds, as Debug often freezes.