### PR TITLE
Make `ChromeDriver` initialize once per class rather than per test. (on `v4.5`)

### DIFF
--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/JavaScriptBuilderElementTemplateTests.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/JavaScriptBuilderElementTemplateTests.cs
@@ -41,6 +41,12 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
         private JObject jsonData { get; set; } = new();
         private string fullJS { get; set; } = "";
 
+        [ClassInitialize]
+        public static new void ClassInit(TestContext context) => JavaScriptBuilderElementTestsBase.ClassInit(context).Wait();
+
+        [ClassCleanup]
+        public static new void ClassCleanup() => JavaScriptBuilderElementTestsBase.ClassCleanup().Wait();
+
         [TestInitialize]
         public override async Task Init()
         {

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/JavaScriptBuilderElementTests.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/JavaScriptBuilderElementTests.cs
@@ -51,6 +51,12 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
         private CancellationTokenSource clientServerTokenSource;
         private HttpListener _clientServer;
 
+        [ClassInitialize]
+        public static new void ClassInit(TestContext context) => JavaScriptBuilderElementTestsBase.ClassInit(context).Wait();
+
+        [ClassCleanup]
+        public static new void ClassCleanup() => JavaScriptBuilderElementTestsBase.ClassCleanup().Wait();
+
         /// <summary>
         /// Initialise the test.
         /// </summary>


### PR DESCRIPTION
### Changes

- Move Driver constructor/`Quit` calls to static `ClassInit`/`ClassCleanup` methods.

### Why

- https://github.com/51Degrees/pipeline-dotnet/actions/runs/13154247404/job/36707698313#step:5:297

### Test runs

- ✅ https://github.com/postindustria-tech/pipeline-dotnet/actions/runs/13163422918