### PR TITLE
Support `IPAddress` and `IWeightedValue` in `JsonBuilderElement`

### DIFF
--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JsonBuilderElement/Converters/IPAddressValueConverter.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JsonBuilderElement/Converters/IPAddressValueConverter.cs
@@ -1,0 +1,106 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2023 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+using FiftyOne.Pipeline.Engines.Data;
+using Newtonsoft.Json;
+using System;
+using System.Net;
+
+namespace FiftyOne.Pipeline.JsonBuilder.Converters
+{
+    /// <summary>
+    /// A <see cref="JsonConverter"/> that converts 
+    /// <see cref="IPAddress"/> instances into JSON data.
+    /// </summary>
+    public class IPAddressValueConverter : JsonConverter
+    {
+        /// <summary>
+        /// If true then this converter can be used for reading as well
+        /// as writing JSON.
+        /// </summary>
+        public override bool CanRead => false;
+
+        /// <summary>
+        /// Returns true if the converter can convert objects of the 
+        /// supplied type.
+        /// </summary>
+        /// <param name="objectType">
+        /// The type to check against.
+        /// </param>
+        /// <returns>
+        /// True if the converter can convert the supplied type.
+        /// False if not.
+        /// </returns>
+        public override bool CanConvert(Type objectType)
+        {
+            return typeof(IPAddress).IsAssignableFrom(objectType);
+        }
+
+        /// <summary>
+        /// Convert the data from the given reader.
+        /// </summary>
+        /// <param name="reader">
+        /// The reader to read from.
+        /// </param>
+        /// <param name="objectType">
+        /// The type of the object to return.
+        /// </param>
+        /// <param name="existingValue">
+        /// ??
+        /// </param>
+        /// <param name="serializer">
+        /// The serializer to use when reading the JSON.
+        /// </param>
+        /// <returns>
+        /// The data object.
+        /// </returns>
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Write the given value to JSON
+        /// </summary>
+        /// <param name="writer">
+        /// The writer to use when writing the output.
+        /// </param>
+        /// <param name="value">
+        /// The value to be converted to JSON
+        /// </param>
+        /// <param name="serializer">
+        /// Not used.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if one of the supplied parameters is null.
+        /// </exception>
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            if (writer == null) throw new ArgumentNullException(nameof(writer));
+            if (value == null) throw new ArgumentNullException(nameof(value));
+            if (serializer == null) throw new ArgumentNullException(nameof(serializer));
+
+            var v = value as IPAddress;
+            serializer.Serialize(writer, v?.ToString());
+        }
+    }
+}

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JsonBuilderElement/Converters/WeightedValueConverter.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JsonBuilderElement/Converters/WeightedValueConverter.cs
@@ -1,0 +1,116 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2023 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+using FiftyOne.Pipeline.Core.Data;
+using FiftyOne.Pipeline.Engines.Data;
+using Newtonsoft.Json;
+using System;
+using System.Linq;
+using System.Net;
+using System.Collections.Generic;
+
+namespace FiftyOne.Pipeline.JsonBuilder.Converters
+{
+    /// <summary>
+    /// A <see cref="JsonConverter"/> that converts 
+    /// <see cref="IWeightedValue{T}"/> instances into JSON data.
+    /// </summary>
+    public class WeightedValueConverter : JsonConverter
+    {
+        /// <summary>
+        /// If true then this converter can be used for reading as well
+        /// as writing JSON.
+        /// </summary>
+        public override bool CanRead => false;
+
+        /// <summary>
+        /// Returns true if the converter can convert objects of the 
+        /// supplied type.
+        /// </summary>
+        /// <param name="objectType">
+        /// The type to check against.
+        /// </param>
+        /// <returns>
+        /// True if the converter can convert the supplied type.
+        /// False if not.
+        /// </returns>
+        public override bool CanConvert(Type objectType)
+            => objectType.GetInterfaces().Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IWeightedValue<>));
+
+        /// <summary>
+        /// Convert the data from the given reader.
+        /// </summary>
+        /// <param name="reader">
+        /// The reader to read from.
+        /// </param>
+        /// <param name="objectType">
+        /// The type of the object to return.
+        /// </param>
+        /// <param name="existingValue">
+        /// ??
+        /// </param>
+        /// <param name="serializer">
+        /// The serializer to use when reading the JSON.
+        /// </param>
+        /// <returns>
+        /// The data object.
+        /// </returns>
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Write the given value to JSON
+        /// </summary>
+        /// <param name="writer">
+        /// The writer to use when writing the output.
+        /// </param>
+        /// <param name="value">
+        /// The value to be converted to JSON
+        /// </param>
+        /// <param name="serializer">
+        /// Not used.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if one of the supplied parameters is null.
+        /// </exception>
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            if (writer == null) throw new ArgumentNullException(nameof(writer));
+            if (value == null) throw new ArgumentNullException(nameof(value));
+            if (serializer == null) throw new ArgumentNullException(nameof(serializer));
+
+            serializer.Serialize(writer, new Dictionary<string, object>
+            {
+                { 
+                    nameof(IWeightedValue<string>.RawWeighting),
+                    value.GetType().GetProperty(nameof(IWeightedValue<string>.RawWeighting)).GetValue(value)
+                },
+                { 
+                    nameof(IWeightedValue<string>.Value),
+                    value.GetType().GetProperty(nameof(IWeightedValue<string>.Value)).GetValue(value)
+                },
+            });
+        }
+    }
+}

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JsonBuilderElementTests/JsonBuilderElementTests.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JsonBuilderElementTests/JsonBuilderElementTests.cs
@@ -495,7 +495,10 @@ namespace FiftyOne.Pipeline.JsonBuilderElementTests
             List,
             APV_String,
             APV_JavaScript,
-            APV_List
+            APV_List,
+            Weighted_String,
+            APV_Weighted_String,
+            APV_Weighted_List,
         }
         public static IEnumerable<object[]> SerializationTestGenerator()
         {
@@ -560,11 +563,17 @@ carriage return and new line
             expectedValue = expectedValue.Replace(@"\r", @"");
             expectedValue = valueOfProperty == null ? expectedValue : $"\"{expectedValue}\"";
 
+            const ushort rawWeighting = 42;
+
             // Create the object to be serialized
             switch (typeToBeTested)
             {
                 case TypeToBeTested.String:
                     valueInDict = valueOfProperty;
+                    break;
+                case TypeToBeTested.Weighted_String:
+                    valueInDict = new WeightedValue<string>(rawWeighting, valueOfProperty);
+                    expectedValue = $@"{{""{nameof(IWeightedValue<string>.RawWeighting).ToLower()}"": {rawWeighting},""{nameof(IWeightedValue<string>.Value).ToLower()}"": {expectedValue}}}";
                     break;
                 case TypeToBeTested.JavaScript:
                     valueInDict = new JavaScript(valueOfProperty);
@@ -585,6 +594,18 @@ carriage return and new line
                     valueInDict = new AspectPropertyValue<IReadOnlyList<string>>(new List<string>() { valueOfProperty });
                     expectedValue = $@"[
                       {expectedValue}
+                    ]";
+                    break;
+                case TypeToBeTested.APV_Weighted_String:
+                    valueInDict = new AspectPropertyValue<WeightedValue<string>>(new WeightedValue<string>(rawWeighting, valueOfProperty));
+                    expectedValue = $@"{{""{nameof(IWeightedValue<string>.RawWeighting).ToLower()}"": {rawWeighting},""{nameof(IWeightedValue<string>.Value).ToLower()}"": {expectedValue}}}";
+                    break;
+                case TypeToBeTested.APV_Weighted_List:
+                    valueInDict = new AspectPropertyValue<IReadOnlyList<WeightedValue<string>>>(new List<WeightedValue<string>>() { 
+                        new WeightedValue<string>(rawWeighting, valueOfProperty),
+                    });
+                    expectedValue = $@"[
+                      {{""{nameof(IWeightedValue<string>.RawWeighting).ToLower()}"": {rawWeighting},""{nameof(IWeightedValue<string>.Value).ToLower()}"": {expectedValue}}}
                     ]";
                     break;
                 default:

--- a/Web Integration/Tests/FiftyOne.Pipeline.Web.Framework.Tests/app.config
+++ b/Web Integration/Tests/FiftyOne.Pipeline.Web.Framework.Tests/app.config
@@ -8,7 +8,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.1" newVersion="8.0.0.1"/>
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Configuration.FileExtensions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
@@ -16,11 +16,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.FileProviders.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.1" newVersion="8.0.0.1"/>
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.1" newVersion="8.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.FileProviders.Physical" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.1" newVersion="8.0.0.1"/>
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.1" newVersion="8.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral"/>


### PR DESCRIPTION
### Changes

- Add serializers and test cases for `IPAddress` and `IWeightedValue` support in `JsonBuilderElement`.
- Fix binding redirects in `MathExample` test.