### PR TITLE
FIX improve test robustness

### DIFF
--- a/Tests/FiftyOne.Pipeline.Engines.Tests/Services/DataUpdateServiceTests.cs
+++ b/Tests/FiftyOne.Pipeline.Engines.Tests/Services/DataUpdateServiceTests.cs
@@ -876,6 +876,8 @@ namespace FiftyOne.Pipeline.Engines.Tests.Services
                 _dataUpdate.RegisterDataFile(file);
                 // Wait until processing is complete.
                 completeFlag.Wait(TEST_TIMEOUT_MS);
+                // Give the background thread a moment to finish cleanup and release locks
+                Thread.Sleep(100);
 
                 DumpLoggerLogs();
 


### PR DESCRIPTION
## What changed
Added timeout in cleanup to unlock the logger.   

## Why? 
Sometimes we observe these faillures in CI: 
https://github.com/51Degrees/pipeline-dotnet/actions/runs/18960963342/job/54147937590#step:5:792

> One or more errors occurred. (Assert.Fail failed. [2025-10-31T02:42:46.9228363+00:00] Failed to lock _logger in 1000ms) (TestCleanup method FiftyOne.Pipeline.Engines.Tests.Services.DataUpdateServiceTests.Cleanup threw exception. Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException: Assert.Fail failed. [2025-10-31T02:42:48.7871568+00:00] Failed to lock _logger in 1000ms.)
