### PR TITLE
FIX: Check GenericTypeArguments length.

### DIFF
--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JsonBuilderElement/FlowElement/JsonBuilderElement.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JsonBuilderElement/FlowElement/JsonBuilderElement.cs
@@ -691,8 +691,7 @@ namespace FiftyOne.Pipeline.JsonBuilder.FlowElement
                 // recursively call this method for each instance
                 // in the list.
                 if (propertyValue is IList elementDatas &&
-                    (typeof(IElementData).IsAssignableFrom(propertyValue.GetType().GetElementType()) ||
-                    typeof(IElementData).IsAssignableFrom(propertyValue.GetType().GenericTypeArguments[0])))
+                    IsContainerFor<IElementData>(propertyValue.GetType()))
                 {
                     var results = new List<object>();
                     foreach (var elementData in elementDatas)
@@ -721,6 +720,15 @@ namespace FiftyOne.Pipeline.JsonBuilder.FlowElement
             {
                 jsonValues.Add(name + "evidenceproperties", evidenceProperties);
             }
+        }
+
+        private static bool IsContainerFor<TTarget>(Type type)
+        {
+            if (type.GetElementType() is Type elementType)
+                return typeof(TTarget).IsAssignableFrom(elementType);
+            if (type.GetGenericArguments() is Type[] args && args.Length > 0)
+                return typeof(TTarget).IsAssignableFrom(args[0]);
+            return typeof(TTarget).IsAssignableFrom(type);
         }
 
         /// <summary>


### PR DESCRIPTION
### Changes

- Check `GenericTypeArguments` length.

### Why

Exception thrown when given `FiftyOne.License.Product[]` :
```
System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at FiftyOne.Pipeline.JsonBuilder.FlowElement.JsonBuilderElement.AddJsonValuesForProperty(IFlowData flowData, Dictionary`2 jsonValues, String dataPath, String name, Object value, PipelineConfig config, Boolean includeValueDataOnly)
   at FiftyOne.Pipeline.JsonBuilder.FlowElement.JsonBuilderElement.GetValues(IFlowData flowData, String dataPath, IReadOnlyDictionary`2 sourceData, PipelineConfig config)
   at FiftyOne.Pipeline.JsonBuilder.FlowElement.JsonBuilderElement.GetAllProperties(IFlowData data, PipelineConfig config)
   at FiftyOne.Pipeline.JsonBuilder.FlowElement.JsonBuilderElement.BuildJson(IFlowData data, PipelineConfig config, Boolean requireSequenceNumber)
   at FiftyOne.Pipeline.JsonBuilder.FlowElement.JsonBuilderElement.BuildAndInjectJSON(IFlowData data, IJsonBuilderElementData elementData, Boolean requireSequenceNumber)
   at FiftyOne.Pipeline.JsonBuilder.FlowElement.JsonBuilderElement.ProcessInternal(IFlowData data)
   at FiftyOne.Pipeline.Core.FlowElements.FlowElementBase`2.Process(IFlowData data)
   at FiftyOne.Pipeline.Core.FlowElements.Pipeline.Process(IFlowData data)
```
<img width="2007" height="1149" alt="Screenshot 2025-11-29 103643" src="https://github.com/user-attachments/assets/037e6b27-5f30-4be2-b722-90d60ba616c6" />

