### PR TITLE
FIX: remove duplicated dependencies

### DIFF
--- a/Tests/FiftyOne.Pipeline.Core.Tests/FiftyOne.Pipeline.Core.Tests.csproj
+++ b/Tests/FiftyOne.Pipeline.Core.Tests/FiftyOne.Pipeline.Core.Tests.csproj
@@ -13,7 +13,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.9.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.9.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/FiftyOne.Pipeline.Engines.FiftyOne.Tests/FiftyOne.Pipeline.Engines.FiftyOne.Tests.csproj
+++ b/Tests/FiftyOne.Pipeline.Engines.FiftyOne.Tests/FiftyOne.Pipeline.Engines.FiftyOne.Tests.csproj
@@ -15,7 +15,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.9.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.9.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/FiftyOne.Pipeline.Engines.Tests/FiftyOne.Pipeline.Engines.Tests.csproj
+++ b/Tests/FiftyOne.Pipeline.Engines.Tests/FiftyOne.Pipeline.Engines.Tests.csproj
@@ -24,7 +24,6 @@
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.9.3" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.9.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
use transitive dependencies to prevent package version downgrade conflicts when transitive dependency updates