### PR TITLE
Use `SharpZipLib` to decompress GZip if target is below .NET 8.

### DIFF
--- a/FiftyOne.Pipeline.Engines/FiftyOne.Pipeline.Engines.csproj
+++ b/FiftyOne.Pipeline.Engines/FiftyOne.Pipeline.Engines.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <Platforms>AnyCPU</Platforms>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -41,6 +41,10 @@
     <PackageReference Include="FiftyOne.Caching" Version="4.4.23" />
     <PackageReference Include="FiftyOne.Common" Version="4.5.4" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="SharpZipLib" Version="1.4.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FiftyOne.Pipeline.Engines/Services/DataUpdateService.cs
+++ b/FiftyOne.Pipeline.Engines/Services/DataUpdateService.cs
@@ -39,6 +39,10 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
+#if !NET8_0_OR_GREATER
+using ICSharpCode.SharpZipLib.GZip;
+#endif
+
 namespace FiftyOne.Pipeline.Engines.Services
 {
     /// <summary>
@@ -1314,8 +1318,16 @@ namespace FiftyOne.Pipeline.Engines.Services
 		{
 			AutoUpdateStatus status = AutoUpdateStatus.AUTO_UPDATE_IN_PROGRESS;
 			compressedDataStream.Position = 0;
+#if !NET8_0_OR_GREATER
+			using (var fis = new GZipInputStream(
+				compressedDataStream)
+			{
+                IsStreamOwner = false,
+            })
+#else
 			using (var fis = new GZipStream(
 				compressedDataStream, CompressionMode.Decompress, true))
+#endif
 			{
 				fis.CopyTo(uncompressedDataStream);
             }


### PR DESCRIPTION
### Changes

- Make `FiftyOne.Pipeline.Engines` multi-target
  - Add `net8.0` to `netstandard2.0`
- Conditionally add `SharpZipLib`
  - only for `netstandard2.0`
- Conditionally use `SharpZipLib`
  - only if NOT `NET8_0_OR_GREATER`

### Why

- https://github.com/51Degrees/pipeline-dotnet/issues/252