### PR TITLE
Share usage testing 

### DIFF
--- a/Tests/FiftyOne.Pipeline.Benchmarks/FiftyOne.Pipeline.Benchmarks.csproj
+++ b/Tests/FiftyOne.Pipeline.Benchmarks/FiftyOne.Pipeline.Benchmarks.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/FiftyOne.Pipeline.Core.Tests/Data/FlowDataTests.cs
+++ b/Tests/FiftyOne.Pipeline.Core.Tests/Data/FlowDataTests.cs
@@ -794,7 +794,6 @@ namespace FiftyOne.Pipeline.Core.Tests.Data
 
         public interface IDisposableData : IElementData, IDisposable
         {
-
         }
 
         /// <summary>

--- a/Tests/FiftyOne.Pipeline.Core.Tests/FiftyOne.Pipeline.Core.Tests.csproj
+++ b/Tests/FiftyOne.Pipeline.Core.Tests/FiftyOne.Pipeline.Core.Tests.csproj
@@ -23,5 +23,14 @@
   <ItemGroup>
     <Folder Include="Benchmarks\" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <AssemblyAttribute Include="Microsoft.VisualStudio.TestTools.UnitTesting.Parallelize">
+      <_Parameter1>Workers = 0</_Parameter1>
+      <_Parameter1_IsLiteral>true</_Parameter1_IsLiteral>
+      <_Parameter2>Scope = Microsoft.VisualStudio.TestTools.UnitTesting.ExecutionScope.MethodLevel</_Parameter2>
+      <_Parameter2_IsLiteral>true</_Parameter2_IsLiteral>
+    </AssemblyAttribute>
+  </ItemGroup>
 
 </Project>

--- a/Tests/FiftyOne.Pipeline.Engines.FiftyOne.Tests/FiftyOne.Pipeline.Engines.FiftyOne.Tests.csproj
+++ b/Tests/FiftyOne.Pipeline.Engines.FiftyOne.Tests/FiftyOne.Pipeline.Engines.FiftyOne.Tests.csproj
@@ -22,4 +22,13 @@
     <ProjectReference Include="..\..\FiftyOne.Pipeline.Engines.TestHelpers\FiftyOne.Pipeline.Engines.TestHelpers.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <AssemblyAttribute Include="Microsoft.VisualStudio.TestTools.UnitTesting.Parallelize">
+      <_Parameter1>Workers = 0</_Parameter1>
+      <_Parameter1_IsLiteral>true</_Parameter1_IsLiteral>
+      <_Parameter2>Scope = Microsoft.VisualStudio.TestTools.UnitTesting.ExecutionScope.MethodLevel</_Parameter2>
+      <_Parameter2_IsLiteral>true</_Parameter2_IsLiteral>
+    </AssemblyAttribute>
+  </ItemGroup>
+
 </Project>

--- a/Tests/FiftyOne.Pipeline.Engines.FiftyOne.Tests/FlowElements/ShareUsageElementTests.cs
+++ b/Tests/FiftyOne.Pipeline.Engines.FiftyOne.Tests/FlowElements/ShareUsageElementTests.cs
@@ -812,17 +812,33 @@ namespace FiftyOne.Pipeline.Engines.FiftyOne.Tests.FlowElements
         /// 'included query string parameters' value will
         /// result in all query. evidence being shared.
         /// </summary>
+        /// <param name="prefix">
+        /// The prefix for the evidence.
+        /// </param>
+        /// <param name="shareAll">
+        /// True if all evidence should be shared, or false to limit evidence.
+        /// </param>
+        /// <param name="expected">
+        /// True if the header values are expected to be present in the share usage content otherwise false.
+        /// </param>
         [TestMethod]
-        public void ShareUsageElement_NullQueryWhitelist()
+        [DataRow(Core.Constants.EVIDENCE_QUERY_PREFIX, false, true)]
+        [DataRow(Core.Constants.EVIDENCE_HTTPHEADER_PREFIX, false, true)]
+        [DataRow(Core.Constants.EVIDENCE_COOKIE_PREFIX, true, true)]
+        [DataRow(Core.Constants.EVIDENCE_QUERY_PREFIX, true, true)]
+        [DataRow(Core.Constants.EVIDENCE_HTTPHEADER_PREFIX, true, true)]
+        [DataRow(Core.Constants.EVIDENCE_COOKIE_PREFIX, false, false)]
+        public void ShareUsageElement_NullQueryWhitelist(string prefix, bool shareAll, bool expected)
         {
             // Arrange
             CreateShareUsage(1, 1, 1,
                 new List<string>(), null,
-                new List<KeyValuePair<string, string>>());
+                new List<KeyValuePair<string, string>>(),
+                shareAll);
 
             Dictionary<string, object> evidenceData = new Dictionary<string, object>()
             {
-                { Core.Constants.EVIDENCE_QUERY_PREFIX + Core.Constants.EVIDENCE_SEPERATOR + "somevalue", "123" },
+                { prefix + Core.Constants.EVIDENCE_SEPERATOR + "somevalue", "123" },
             };
             var data = MockFlowData.CreateFromEvidence(evidenceData, false);
 
@@ -841,8 +857,63 @@ namespace FiftyOne.Pipeline.Engines.FiftyOne.Tests.FlowElements
             {
                 while (xr.Read()) { }
             }
-            // Check that the expected values are populated.
-            Assert.Contains("<query Name=\"somevalue\"><![CDATA[123]]></query>", _xmlContent[0]);
+            // Check that the expected values are populated or not.
+            Assert.AreEqual(expected, _xmlContent[0].Contains(
+                $"<{prefix} Name=\"somevalue\"><![CDATA[123]]></{prefix}>"));
+        }
+
+        /// <summary>
+        /// A test that checks that share usage of other fields happens when the User-Agent is missing.
+        /// </summary>
+        /// <param name="prefix">
+        /// The prefix for the evidence.
+        /// </param>
+        /// <param name="shareAll">
+        /// True if all evidence should be shared, or false to limit evidence.
+        /// </param>
+        /// <param name="expected">
+        /// True if the header values are expected to be present in the share usage content otherwise false.
+        /// </param>
+        [TestMethod]
+        [DataRow(Core.Constants.EVIDENCE_QUERY_PREFIX, false, true)]
+        [DataRow(Core.Constants.EVIDENCE_HTTPHEADER_PREFIX, false, true)]
+        [DataRow(Core.Constants.EVIDENCE_QUERY_PREFIX, true, true)]
+        [DataRow(Core.Constants.EVIDENCE_HTTPHEADER_PREFIX, true, true)]
+        public void ShareUsageElement_MissingUserAgent(string prefix, bool shareAll, bool expected)
+        {
+            // Arrange
+            CreateShareUsage(1, 1, 1,
+                new List<string>(), null,
+                new List<KeyValuePair<string, string>>());
+
+            var evidenceData = new Dictionary<string, object>()
+            {
+                { prefix + Core.Constants.EVIDENCE_SEPERATOR + "sec-ch-ua", @"""Google Chrome"";v=""143"", ""Chromium"";v=""143"", ""Not A(Brand"";v=""24""" },
+                { prefix + Core.Constants.EVIDENCE_SEPERATOR + "sec-ch-ua-mobile", "?0" },
+                { prefix + Core.Constants.EVIDENCE_SEPERATOR + "sec-ch-ua-platform", @"""Windows""" },
+                { prefix + Core.Constants.EVIDENCE_SEPERATOR + "sec-ch-ua-platform-version", @"""10.0.0""" },
+                { prefix + Core.Constants.EVIDENCE_SEPERATOR + "sec-ch-ua-model", @"""""" },
+                { prefix + Core.Constants.EVIDENCE_SEPERATOR + "sec-ch-ua-full-version-list", @"""Google Chrome"";v=""143.0.7499.170"", ""Chromium"";v=""143.0.7499.170"", ""Not A(Brand"";v=""24.0.0.0""" }
+            };
+            var data = MockFlowData.CreateFromEvidence(evidenceData, false);
+
+            // Act
+            _shareUsageElement.Process(data.Object);
+            // Wait for the consumer task to finish.
+            WaitForSendDataTask();
+
+            // Assert
+            // Check that the HTTP message was sent and the headers were or weren't present.
+            _httpHandler.VerifySendCalled(1);
+            Assert.HasCount(1, _xmlContent);
+            foreach (var pair in evidenceData)
+            {
+                var key = pair.Key.Substring(pair.Key.IndexOf('.') + 1);
+                var value = pair.Value;
+                Assert.AreEqual(expected, _xmlContent[0].Contains(
+                    $"<{prefix} Name=\"{key}\"><![CDATA[{value}]]></{prefix}>"),
+                    $"Expected '{pair.Key}' to be present");
+            }
         }
 
         /// <summary>

--- a/Tests/FiftyOne.Pipeline.Engines.FiftyOne.Tests/Trackers/ShareUsageTrackerTests.cs
+++ b/Tests/FiftyOne.Pipeline.Engines.FiftyOne.Tests/Trackers/ShareUsageTrackerTests.cs
@@ -192,7 +192,7 @@ namespace FiftyOne.Pipeline.Engines.FiftyOne.Tests.Trackers
 			Assert.AreEqual(1, trackedEvents);
 		}
 
-		public DataKey GenerateKey(IEvidenceKeyFilter filter, Dictionary<string, object> evidence)
+        public DataKey GenerateKey(IEvidenceKeyFilter filter, Dictionary<string, object> evidence)
 		{
 			DataKeyBuilder result = new DataKeyBuilder();
 			foreach (var entry in evidence)

--- a/Tests/FiftyOne.Pipeline.Engines.Tests/FiftyOne.Pipeline.Engines.Tests.csproj
+++ b/Tests/FiftyOne.Pipeline.Engines.Tests/FiftyOne.Pipeline.Engines.Tests.csproj
@@ -31,4 +31,13 @@
     <ProjectReference Include="..\..\FiftyOne.Pipeline.Engines\FiftyOne.Pipeline.Engines.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <AssemblyAttribute Include="Microsoft.VisualStudio.TestTools.UnitTesting.Parallelize">
+      <_Parameter1>Workers = 0</_Parameter1>
+      <_Parameter1_IsLiteral>true</_Parameter1_IsLiteral>
+      <_Parameter2>Scope = Microsoft.VisualStudio.TestTools.UnitTesting.ExecutionScope.MethodLevel</_Parameter2>
+      <_Parameter2_IsLiteral>true</_Parameter2_IsLiteral>
+    </AssemblyAttribute>
+  </ItemGroup>
+
 </Project>

--- a/Tests/FiftyOne.Pipeline.Examples.Tests/FiftyOne.Pipeline.Examples.Tests.csproj
+++ b/Tests/FiftyOne.Pipeline.Examples.Tests/FiftyOne.Pipeline.Examples.Tests.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.9.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.9.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.0.2" />
   </ItemGroup>
 
   <ItemGroup>
@@ -19,6 +19,15 @@
     <ProjectReference Include="..\..\Examples\CustomFlowElement\2. On Premise Engine\Examples.OnPremiseEngine.csproj" />
     <ProjectReference Include="..\..\Examples\ResultCaching\Examples.ResultCaching.csproj" />
     <ProjectReference Include="..\..\Examples\UsageSharing\Examples.UsageSharing.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="Microsoft.VisualStudio.TestTools.UnitTesting.Parallelize">
+      <_Parameter1>Workers = 0</_Parameter1>
+      <_Parameter1_IsLiteral>true</_Parameter1_IsLiteral>
+      <_Parameter2>Scope = Microsoft.VisualStudio.TestTools.UnitTesting.ExecutionScope.MethodLevel</_Parameter2>
+      <_Parameter2_IsLiteral>true</_Parameter2_IsLiteral>
+    </AssemblyAttribute>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Changes

1. The tests have been upgraded to address warnings related to MS Test 4.
2. A test is added specifically to check that evidence described in #258 is included in the XML output from usage sharing.