### PR TITLE
FEAT: add CancellationToken to FlowData

### DIFF
--- a/FiftyOne.Pipeline.Core/Data/FlowData.cs
+++ b/FiftyOne.Pipeline.Core/Data/FlowData.cs
@@ -28,6 +28,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading;
 
 [assembly: InternalsVisibleTo("FiftyOne.Pipeline.Web.Tests")]
 [assembly: InternalsVisibleTo("FiftyOne.Pipeline.Core.Tests")]
@@ -98,8 +99,13 @@ namespace FiftyOne.Pipeline.Core.Data
         /// A boolean flag that can be used to stop further elements
         /// from executing.
         /// </summary>
-        public bool Stop { get; set; }
-
+        public bool Stop {
+            get => StopTokenSource.IsCancellationRequested;
+            set { if (value) StopTokenSource.Cancel(); }
+        }
+        
+        /// <inheritdoc/>
+        public CancellationTokenSource StopTokenSource { get; }
 
         /// <summary>
         /// Get a filter that will only include the evidence keys that can 
@@ -126,16 +132,27 @@ namespace FiftyOne.Pipeline.Core.Data
         /// <param name="evidence">
         /// The initial evidence.
         /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used to stop processing of the pipeline.
+        /// Note that this token is linked to the internal cancellation token source for
+        /// this FlowData instance so if the token is canceled then the Stop property
+        /// will return true and processing of the pipeline will stop.
+        /// Cancelling of internal cancellation token source will NOT cancel this token.
+        /// </param>
         internal FlowData(
             ILogger<FlowData> logger,
             IPipelineInternal pipeline,
-            Evidence evidence)
+            Evidence evidence,
+            CancellationToken cancellationToken = default)
         {
             _logger = logger;
             PipelineInternal = pipeline;
             _data = new TypedKeyMap(pipeline?.IsConcurrent ?? false);
             _evidence = evidence;
-
+            
+            StopTokenSource =
+                CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            
             if (_logger != null && _logger.IsEnabled(LogLevel.Debug))
             {
                 _logger.LogDebug($"FlowData '{GetHashCode()}' created.");

--- a/FiftyOne.Pipeline.Core/Data/IFlowData.cs
+++ b/FiftyOne.Pipeline.Core/Data/IFlowData.cs
@@ -24,6 +24,7 @@ using FiftyOne.Pipeline.Core.FlowElements;
 using FiftyOne.Pipeline.Core.TypedMap;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 
 namespace FiftyOne.Pipeline.Core.Data
 {
@@ -37,13 +38,21 @@ namespace FiftyOne.Pipeline.Core.Data
         /// A boolean flag that can be used to stop further elements
         /// from executing.
         /// </summary>
-        [Obsolete("This property will be replaced with a more appropriate " +
-            "mechanism such as a CancellationToken in a future version.")]
+        [Obsolete("This property is replaced StopTokenSource.")]
 #pragma warning disable CA1716 // Identifiers should not match keywords
-        // Marked as obsolete and will be removed in future.
         bool Stop { get; set; }
 #pragma warning restore CA1716 // Identifiers should not match keywords
 
+        /// <summary>
+        /// A CancellationTokenSource that can be used to cancel the processing of
+        /// this flow data. When the CancellationTokenSource is canceled,
+        /// the pipeline should stop processing as soon as possible and
+        /// should not execute any further elements. Note that cancelling the
+        /// CancellationTokenSource does not automatically stop the pipeline, it is up to the
+        /// implementation of the pipeline and the elements to check the token and stop processing when it is canceled.
+        /// </summary>
+        CancellationTokenSource StopTokenSource { get; }
+        
         /// <summary>
         /// The errors that have occurred during processing
         /// </summary>

--- a/FiftyOne.Pipeline.Core/FlowElements/FlowElementBase.cs
+++ b/FiftyOne.Pipeline.Core/FlowElements/FlowElementBase.cs
@@ -208,11 +208,7 @@ namespace FiftyOne.Pipeline.Core.FlowElements
             }
 
             Stopwatch sw = null;
-#pragma warning disable CS0618 // Type or member is obsolete
-            // This usage will be replaced once the Cancellation Token
-            // mechanism is available.
-            if (data.Stop == false)
-#pragma warning restore CS0618 // Type or member is obsolete
+            if (data.StopTokenSource.IsCancellationRequested == false)
             {
                 bool log = Logger.IsEnabled(LogLevel.Debug);
                 if (log)

--- a/FiftyOne.Pipeline.Core/FlowElements/Pipeline.cs
+++ b/FiftyOne.Pipeline.Core/FlowElements/Pipeline.cs
@@ -378,11 +378,7 @@ namespace FiftyOne.Pipeline.Core.FlowElements
                 try
                 {
                     element.Process(data);
-#pragma warning disable CS0618 // Type or member is obsolete
-                    // This usage will be replaced once the Cancellation Token
-                    // mechanism is available.
-                    if (data.Stop) break;
-#pragma warning restore CS0618 // Type or member is obsolete
+                    if (data.StopTokenSource.IsCancellationRequested) break;
                 }
 #pragma warning disable CA1031 // Do not catch general exception types
                 // We want to catch any exception here so that the

--- a/Tests/FiftyOne.Pipeline.Core.Tests/HelperClasses/StopElement.cs
+++ b/Tests/FiftyOne.Pipeline.Core.Tests/HelperClasses/StopElement.cs
@@ -50,11 +50,7 @@ namespace FiftyOne.Pipeline.Core.Tests.HelperClasses
 
         protected override void ProcessInternal(IFlowData data)
         {
-#pragma warning disable CS0618 // Type or member is obsolete
-            // This usage will be replaced once the Cancellation Token
-            // mechanism is available.
-            data.Stop = true;
-#pragma warning restore CS0618 // Type or member is obsolete
+            data.StopTokenSource.Cancel();
         }
 
         protected override void ManagedResourcesCleanup()

--- a/Tests/FiftyOne.Pipeline.Core.Tests/Integration/PipelineIntegrationTests.cs
+++ b/Tests/FiftyOne.Pipeline.Core.Tests/Integration/PipelineIntegrationTests.cs
@@ -130,12 +130,8 @@ namespace FiftyOne.Pipeline.Core.Tests.Integration
             {
                 flowData.Process();
 
-                // Check that the stop flag is set
-#pragma warning disable CS0618 // Type or member is obsolete
-                // This usage will be replaced once the Cancellation Token
-                // mechanism is available.
-                Assert.IsTrue(flowData.Stop);
-#pragma warning restore CS0618 // Type or member is obsolete
+                // Check that the process is canceled
+                Assert.IsTrue(flowData.StopTokenSource.IsCancellationRequested);
             }
             // Check that the second element was never processed
             testElement.Verify(e => e.Process(It.IsAny<IFlowData>()), Times.Never());


### PR DESCRIPTION
IFlowData now exposes a CancellationTokenSource; 
 
The legacy Stop bool delegates to it (get → IsCancellationRequested, set true → Cancel()), so existing callers keep working while   new ones can cooperatively cancel via the token.
   
Replace all usage of obsolete Stop property with StopTokenSource.IsCancellationRequested