### PR TITLE
Unpack `IAspectPropertyValue'1` to underlying type.

### DIFF
--- a/FiftyOne.Pipeline.Core/Data/AccessiblePropertyMetaData.cs
+++ b/FiftyOne.Pipeline.Core/Data/AccessiblePropertyMetaData.cs
@@ -159,6 +159,9 @@ namespace FiftyOne.Pipeline.Core.Data
                 case "List`1":
                 case "IReadOnlyList`1":
                     return "Array";
+                case "AspectPropertyValue`1":
+                case "IAspectPropertyValue`1":
+                    return GetTypeName(type.GetGenericArguments()[0]);
                 default:
                     return type.Name;
             }


### PR DESCRIPTION
### Changes

- Unpack `IAspectPropertyValue'1` to underlying type.

### Why

The framework shouldn't require OnPremise and Cloud data (and engines) to have different types of the same properties.

The consumers should be oblivious to which of the 2 is present in the pipeline.

<img width="521" height="822" alt="image" src="https://github.com/user-attachments/assets/fc8ec123-b020-4f14-9e68-70e9013b4bcd" />
