### PR TITLE
Add `LazyValueConverter` for `System.Lazy<T>` support.

### DIFF
--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JsonBuilderElement/Converters/LazyValueConverter.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JsonBuilderElement/Converters/LazyValueConverter.cs
@@ -1,0 +1,117 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+using Newtonsoft.Json;
+using System;
+using System.Linq;
+
+namespace FiftyOne.Pipeline.JsonBuilder.Converters
+{
+    /// <summary>
+    /// A <see cref="JsonConverter"/> that converts 
+    /// <see cref="Lazy{T}"/> instances into JSON data.
+    /// </summary>
+    public class LazyValueConverter : JsonConverter
+    {
+        /// <summary>
+        /// If true then this converter can be used for reading as well
+        /// as writing JSON.
+        /// </summary>
+        public override bool CanRead => false;
+
+        /// <summary>
+        /// Returns true if the converter can convert objects of the 
+        /// supplied type.
+        /// </summary>
+        /// <param name="objectType">
+        /// The type to check against.
+        /// </param>
+        /// <returns>
+        /// True if the converter can convert the supplied type.
+        /// False if not.
+        /// </returns>
+        public override bool CanConvert(Type objectType)
+        {
+            var typeToCheck = Nullable.GetUnderlyingType(objectType) ?? objectType;
+            while ((typeToCheck is null) == false)
+            {
+                if (typeToCheck.IsGenericType &&
+                    typeToCheck.GetGenericTypeDefinition() == typeof(Lazy<>))
+                    return true;
+
+                typeToCheck = typeToCheck.BaseType;
+            }
+            return false;
+        }
+
+
+        /// <summary>
+        /// Convert the data from the given reader.
+        /// </summary>
+        /// <param name="reader">
+        /// The reader to read from.
+        /// </param>
+        /// <param name="objectType">
+        /// The type of the object to return.
+        /// </param>
+        /// <param name="existingValue">
+        /// ??
+        /// </param>
+        /// <param name="serializer">
+        /// The serializer to use when reading the JSON.
+        /// </param>
+        /// <returns>
+        /// The data object.
+        /// </returns>
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Write the given value to JSON
+        /// </summary>
+        /// <param name="writer">
+        /// The writer to use when writing the output.
+        /// </param>
+        /// <param name="value">
+        /// The value to be converted to JSON
+        /// </param>
+        /// <param name="serializer">
+        /// Not used.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if one of the supplied parameters is null.
+        /// </exception>
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            if (writer == null) throw new ArgumentNullException(nameof(writer));
+            if (value == null) throw new ArgumentNullException(nameof(value));
+            if (serializer == null) throw new ArgumentNullException(nameof(serializer));
+
+            var backedValue = value.GetType()
+                .GetProperty(nameof(Lazy<string>.Value))
+                ?.GetValue(value);
+            serializer.Serialize(writer, backedValue);
+        }
+    }
+}

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JsonBuilderElement/FlowElement/JsonBuilderElement.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JsonBuilderElement/FlowElement/JsonBuilderElement.cs
@@ -127,6 +127,7 @@ namespace FiftyOne.Pipeline.JsonBuilder.FlowElement
         // the property values.
         private static JsonConverter[] JSON_CONVERTERS = new JsonConverter[]
         {
+            new LazyValueConverter(),
             new JavaScriptConverter(),
             new AspectPropertyValueConverter(),
             new IPAddressValueConverter(),

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JsonBuilderElementTests/JsonBuilderElementTests.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JsonBuilderElementTests/JsonBuilderElementTests.cs
@@ -504,6 +504,12 @@ namespace FiftyOne.Pipeline.JsonBuilderElementTests
             Weighted_IP,
             APV_Weighted_IP,
             APV_Weighted_IP_List,
+            Lazy_String,
+            Lazy_String_List,
+            APV_Lazy_String,
+            APV_Lazy_String_List,
+            Lazy_APV_String,
+            Lazy_APV_String_List,
         }
         public static IEnumerable<object[]> SerializationTestGenerator()
         {
@@ -651,6 +657,39 @@ carriage return and new line
                     });
                     expectedValue = $@"[
                       {{""{nameof(IWeightedValue<string>.RawWeighting).ToLower()}"": {rawWeighting},""{nameof(IWeightedValue<string>.Value).ToLower()}"": {expectedValue}}}
+                    ]";
+                    break;
+                case TypeToBeTested.Lazy_String:
+                    valueInDict = new Lazy<string>(valueOfProperty);
+                    break;
+                case TypeToBeTested.Lazy_String_List:
+                    valueInDict = new Lazy<IReadOnlyList<string>>(
+                        new List<string>() { valueOfProperty });
+                    expectedValue = $@"[
+                      {expectedValue}
+                    ]";
+                    break;
+                case TypeToBeTested.APV_Lazy_String:
+                    valueInDict = new AspectPropertyValue<Lazy<string>>(
+                        new(valueOfProperty));
+                    break;
+                case TypeToBeTested.APV_Lazy_String_List:
+                    valueInDict = new AspectPropertyValue<Lazy<IReadOnlyList<string>>>(
+                        new(new List<string>() { valueOfProperty }));
+                    expectedValue = $@"[
+                      {expectedValue}
+                    ]";
+                    break;
+                case TypeToBeTested.Lazy_APV_String:
+                    valueInDict = new Lazy<IAspectPropertyValue<string>>(
+                        new AspectPropertyValue<string>(valueOfProperty));
+                    break;
+                case TypeToBeTested.Lazy_APV_String_List:
+                    valueInDict = new Lazy<IAspectPropertyValue<IReadOnlyList<string>>>(
+                        new AspectPropertyValue<IReadOnlyList<string>>(
+                            new List<string>() { valueOfProperty }));
+                    expectedValue = $@"[
+                      {expectedValue}
                     ]";
                     break;
                 default:


### PR DESCRIPTION
### Changes

- Add `LazyValueConverter` for [`System.Lazy<T>`](https://learn.microsoft.com/en-us/dotnet/api/system.lazy-1?view=netstandard-2.0) support.
  - Add relevant cases to unit tests.

#### Behavior

Currently `Lazy<IAspectPropertyValue<string>>` is serialized as:

```json{
{
  "isvaluecreated" : true,
  "value" : null
},
```
with changes -- value is unpacked/computed at serialization time.

### Why

> Lazy loading the DiD properties which are computationally expensive.

- https://github.com/51Degrees/cloud/pull/29#pullrequestreview-4178459217
- https://github.com/51Degrees/cloud/pull/29#discussion_r3145785560