### PR TITLE
Add original exception message to `BuildInformativeErrorMessage`.

### DIFF
--- a/FiftyOne.Pipeline.Core/FlowElements/PipelineBuilder.cs
+++ b/FiftyOne.Pipeline.Core/FlowElements/PipelineBuilder.cs
@@ -228,18 +228,20 @@ namespace FiftyOne.Pipeline.Core.FlowElements
             var subElementBuilderNames = 
                 (elementOptions.SubElements == null || 
                 elementOptions.SubElements.Count == 0)
-                ?  "No SubElements" 
-                :  String.Join(",", elementOptions.SubElements                  
+                ? "No SubElements" 
+                : string.Join(",", elementOptions.SubElements                  
                     .Select(i => i.BuilderName));
 
+            var exceptionMessage = ex.Message ?? "(No exception message)";
             var innerException = ex.InnerException != null ?
                 ex.InnerException.Message :
                 "No Inner Exception.";
 
             sb.Append("BuilderName: ");
-            sb.AppendLine(elementOptions.BuilderName);
+            sb.AppendLine(builderName);
             sb.Append("SubElement Builder Names: ");
             sb.AppendLine(subElementBuilderNames);
+            sb.AppendLine(exceptionMessage);
             sb.AppendLine(innerException);
             return sb.ToString();
         }


### PR DESCRIPTION
### Changes

- Add original exception message to `BuildInformativeErrorMessage`.

### Why

Original message is not propagated:
```txt
Initialization method FiftyOne.DiD.OnPremise.Tests.DiDCloudEngineProcessingTests.TestInitialize threw exception. FiftyOne.Pipeline.Core.Exceptions.PipelineConfigurationException: Configuration failed to build.
BuilderName: DiDOnPremiseEngineBuilder
SubElement Builder Names: No SubElements
No Inner Exception.
.
   at FiftyOne.Pipeline.Core.FlowElements.PipelineBuilder.BuildFromConfiguration(PipelineOptions options)
```
^ No helpful data is available beyond "Configuration failed to build."

### Goal

Re-add original helpful message:
```txt
Builder 'FiftyOne.DiD.OnPremise.FlowElements.DiDOnPremiseEngineBuilder' for element 4 has no 'Set' methods or 'Build' methods that match (case-insensitively) the following parameters: IDDOMAINIDDOMAIN. The available configuration methods on this builder are: 
SetIdDomain (RuntimeParameterInfo)
The available 'Build' methods have the following signatures: 
```