### PR TITLE
Add FiftyOne.Did NuGet for parsing 51Did values

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,6 @@
 [submodule "JavascriptTemplates"]
 	path = FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElement/Templates
 	url = ../javascript-templates
+[submodule "owid-dotnet"]
+	path = owid-dotnet
+	url = https://github.com/SWAN-community/owid-dotnet.git

--- a/FiftyOne.Did/FiftyOne.Did.csproj
+++ b/FiftyOne.Did/FiftyOne.Did.csproj
@@ -1,0 +1,58 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <AssemblyName>FiftyOne.Did</AssemblyName>
+    <RootNamespace>FiftyOne.Did</RootNamespace>
+    <Platforms>AnyCPU</Platforms>
+    <DocumentationFile>FiftyOne.Did.xml</DocumentationFile>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Nullable>enable</Nullable>
+
+    <!-- NuGet package properties -->
+    <PackageId>FiftyOne.Did</PackageId>
+    <Title>51Degrees Device Identifier (51Did) parser</Title>
+    <PackageDescription>Parses a 51Degrees device identifier (51Did) value as returned by the 51Degrees Cloud service. The 51Did is an OWID envelope whose payload encodes a 1-byte usage flags bit-mask, a 4-byte little-endian License Id, and a 32-byte SHA-256 probabilistic identifier hash. The FodId type inherits from Owid.Client.Model.Owid (SWAN-community/owid-dotnet) and unpacks those three payload fields.</PackageDescription>
+    <Authors>51Degrees Engineering</Authors>
+    <PackageLicenseExpression>EUPL-1.2</PackageLicenseExpression>
+    <PackageIconUrl>https://51degrees.com/portals/0/Logos/Square%20Logo.png?width=64</PackageIconUrl>
+    <Copyright>51Degrees Mobile Experts Limited</Copyright>
+    <PackageTags>51degrees,51did,fodid,did,pipeline,owid</PackageTags>
+    <RepositoryUrl>https://github.com/51Degrees/pipeline-dotnet</RepositoryUrl>
+    <PackageIcon>51d-logo.png</PackageIcon>
+    <PackageProjectUrl>https://51degrees.com</PackageProjectUrl>
+    <Description>Parses a 51Degrees device identifier (51Did) value as returned by the 51Degrees Cloud service.</Description>
+    <RepositoryType>git</RepositoryType>
+    <NeutralLanguage>en</NeutralLanguage>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+
+  <!-- Compile the Owid.Client source directly into FiftyOne.Did.dll. The
+       owid-dotnet submodule provides the source; we deliberately do NOT
+       reference Owid.Client.csproj so there is no separate assembly to
+       ship or to surface as a NuGet dependency. -->
+  <ItemGroup>
+    <Compile Include="..\owid-dotnet\Owid.Client\**\*.cs"
+             Exclude="..\owid-dotnet\Owid.Client\obj\**\*.cs;..\owid-dotnet\Owid.Client\bin\**\*.cs"
+             LinkBase="Owid" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+    <None Include="..\Images\51d-logo.png">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/FiftyOne.Did/Model/FodId.cs
+++ b/FiftyOne.Did/Model/FodId.cs
@@ -1,0 +1,180 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+using System;
+
+namespace FiftyOne.Did.Model
+{
+    /// <summary>
+    /// An OWID whose payload encodes the three fields of a 51Did: a 1-byte
+    /// usage flags bitmask, a 4-byte little-endian License Id, and the
+    /// 32-byte SHA-256 probabilistic identifier hash.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Payload layout (37 bytes):
+    /// </para>
+    /// <list type="table">
+    ///   <listheader><term>Offset</term><term>Length</term><term>Field</term></listheader>
+    ///   <item><term>0</term><term>1</term><term>Flags (uint8 bit-mask)</term></item>
+    ///   <item><term>1</term><term>4</term><term>LicenseId (uint32 LE)</term></item>
+    ///   <item><term>5</term><term>32</term><term>Hash (SHA-256)</term></item>
+    /// </list>
+    /// <para>
+    /// Inherits <see cref="Owid"/> so callers can use OWID-level features
+    /// (signature verification, base64 round-tripping) directly on a
+    /// <see cref="FodId"/> instance.
+    /// </para>
+    /// <para>
+    /// This class does NOT verify the OWID signature on construction. Callers
+    /// wanting cryptographic verification should call the extension methods on
+    /// <see cref="Owid"/> on this instance after construction.
+    /// </para>
+    /// </remarks>
+    public class FodId : Owid.Client.Model.Owid
+    {
+        /// <summary>
+        /// Byte offset of the Flags field within the payload.
+        /// </summary>
+        public const int FlagsOffset = 0;
+
+        /// <summary>
+        /// Byte offset of the License Id field within the payload.
+        /// </summary>
+        public const int LicenseIdOffset = 1;
+
+        /// <summary>
+        /// Byte length of the License Id field.
+        /// </summary>
+        public const int LicenseIdLength = 4;
+
+        /// <summary>
+        /// Byte offset of the Hash field within the payload.
+        /// </summary>
+        public const int HashOffset = 5;
+
+        /// <summary>
+        /// Byte length of the Hash field (SHA-256).
+        /// </summary>
+        public const int HashLength = 32;
+
+        /// <summary>
+        /// Minimum byte length of a 51Did payload (Flags + LicenseId + Hash).
+        /// </summary>
+        public const int PayloadLength = HashOffset + HashLength;
+
+        /// <summary>
+        /// The 1-byte usage flags bit-mask from the payload.
+        /// </summary>
+        public byte Flags { get; private set; }
+
+        /// <summary>
+        /// The 4-byte little-endian License Id from the payload.
+        /// </summary>
+        public uint LicenseId { get; private set; }
+
+        /// <summary>
+        /// The 32-byte SHA-256 probabilistic identifier hash from the payload.
+        /// </summary>
+        public byte[] Hash { get; private set; } = Array.Empty<byte>();
+
+        /// <summary>
+        /// Parse a 51Did from its base64-encoded OWID string.
+        /// </summary>
+        /// <param name="base64">
+        /// Base64 of the full OWID envelope (version + domain + date +
+        /// length-prefixed payload + 64-byte signature) as produced by the
+        /// 51Degrees cloud service.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="base64"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="FormatException">
+        /// Thrown by the underlying OWID parser when <paramref name="base64"/>
+        /// is not valid Base64.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// Thrown when the decoded payload is shorter than
+        /// <see cref="PayloadLength"/> bytes.
+        /// </exception>
+        public FodId(string base64) : base(base64) => Unpack(nameof(base64));
+
+        /// <summary>
+        /// Parse a 51Did from the raw bytes of an OWID envelope.
+        /// </summary>
+        /// <param name="buffer">The OWID envelope bytes.</param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="buffer"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// Thrown when the payload is shorter than <see cref="PayloadLength"/>
+        /// bytes.
+        /// </exception>
+        public FodId(byte[] buffer) : base(buffer) => Unpack(nameof(buffer));
+
+        /// <summary>
+        /// Promote an already-parsed OWID into a 51Did by unpacking its
+        /// payload fields. The OWID's Version, Domain, Date, Payload and
+        /// Signature are copied by reference onto the new instance.
+        /// </summary>
+        /// <param name="owid">The already-parsed OWID envelope.</param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="owid"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// Thrown when <paramref name="owid"/>'s payload is shorter than
+        /// <see cref="PayloadLength"/> bytes.
+        /// </exception>
+        public FodId(Owid.Client.Model.Owid owid) : base()
+        {
+            if (owid == null)
+            {
+                throw new ArgumentNullException(nameof(owid));
+            }
+            Version = owid.Version;
+            Domain = owid.Domain;
+            Date = owid.Date;
+            Payload = owid.Payload;
+            Signature = owid.Signature;
+            Unpack(nameof(owid));
+        }
+
+        private void Unpack(string paramName)
+        {
+            if (Payload == null || Payload.Length < PayloadLength)
+            {
+                throw new ArgumentException(
+                    $"51Did payload must be at least {PayloadLength} bytes; " +
+                    $"got {Payload?.Length ?? 0}.",
+                    paramName);
+            }
+            Flags = Payload[FlagsOffset];
+            LicenseId = (uint)(
+                Payload[LicenseIdOffset]
+                | (Payload[LicenseIdOffset + 1] << 8)
+                | (Payload[LicenseIdOffset + 2] << 16)
+                | (Payload[LicenseIdOffset + 3] << 24));
+            Hash = new byte[HashLength];
+            Array.Copy(Payload, HashOffset, Hash, 0, HashLength);
+        }
+    }
+}

--- a/FiftyOne.Did/README.md
+++ b/FiftyOne.Did/README.md
@@ -1,0 +1,53 @@
+# FiftyOne.Did
+
+Strongly-typed .NET parser for the 51Did (51Degrees device identifier) value
+returned by the 51Degrees Cloud service.
+
+A 51Did is an OWID envelope whose payload encodes three fields:
+
+| Offset | Length | Field      | Type                              |
+|-------:|-------:|------------|-----------------------------------|
+|      0 |      1 | Flags      | uint8 usage-flags bit-mask        |
+|      1 |      4 | LicenseId  | uint32 (little-endian)            |
+|      5 |     32 | Hash       | SHA-256 probabilistic identifier  |
+
+`FodId` inherits from `Owid.Client.Model.Owid` (see
+[SWAN-community/owid-dotnet](https://github.com/SWAN-community/owid-dotnet)),
+so a `FodId` instance behaves as an OWID for all OWID-level concerns
+(domain, date, payload bytes, signature, base64 round-tripping) and adds
+strongly-typed accessors for the three 51Did payload fields on top.
+
+## Usage
+
+```csharp
+using FiftyOne.Did.Model;
+
+var fodId = new FodId(base64FromCloudService);
+
+byte    flags     = fodId.Flags;
+uint    licenseId = fodId.LicenseId;
+byte[]  hash      = fodId.Hash;        // 32 bytes
+
+// Inherited OWID-level fields.
+string   domain   = fodId.Domain;
+DateTime date     = fodId.Date;
+
+// Inherited OWID-level operations.
+bool     verified = await fodId.VerifyAsync(publicKey);
+string   roundTrip = fodId.AsBase64();
+```
+
+## Non-goals
+
+- **Signature verification on construction.** Constructing a `FodId` does
+  not check the signature. Call `VerifyAsync` (inherited from `Owid`) when
+  needed.
+- **Construction of new 51Dids.** This is a parser. New 51Dids are issued by
+  the 51Degrees cloud / on-premise hashing engines.
+
+## See also
+
+- `https://github.com/SWAN-community/owid-dotnet` — OWID envelope library this
+  package builds on.
+- The 51Did inspector page on `51degrees.com/developers/fodid-inspector` for
+  a visual breakdown of the same byte layout.

--- a/FiftyOne.Pipeline.sln
+++ b/FiftyOne.Pipeline.sln
@@ -52,6 +52,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "UsageSharing", "UsageSharin
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Examples.UsageSharing", "Examples\UsageSharing\Examples.UsageSharing.csproj", "{E6C265A5-BD88-4C12-821F-CF505D1DCB76}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FiftyOne.Did", "FiftyOne.Did\FiftyOne.Did.csproj", "{3C365D6D-3112-4BA9-AFB6-359C4F15721B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FiftyOne.Did.Tests", "Tests\FiftyOne.Did.Tests\FiftyOne.Did.Tests.csproj", "{BD49B7A4-DCFD-4897-AE77-4BFA24CD5E40}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -180,6 +184,22 @@ Global
 		{E6C265A5-BD88-4C12-821F-CF505D1DCB76}.CoreRelease|Any CPU.Build.0 = Release|Any CPU
 		{E6C265A5-BD88-4C12-821F-CF505D1DCB76}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E6C265A5-BD88-4C12-821F-CF505D1DCB76}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3C365D6D-3112-4BA9-AFB6-359C4F15721B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3C365D6D-3112-4BA9-AFB6-359C4F15721B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3C365D6D-3112-4BA9-AFB6-359C4F15721B}.CoreDebug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3C365D6D-3112-4BA9-AFB6-359C4F15721B}.CoreDebug|Any CPU.Build.0 = Debug|Any CPU
+		{3C365D6D-3112-4BA9-AFB6-359C4F15721B}.CoreRelease|Any CPU.ActiveCfg = Debug|Any CPU
+		{3C365D6D-3112-4BA9-AFB6-359C4F15721B}.CoreRelease|Any CPU.Build.0 = Debug|Any CPU
+		{3C365D6D-3112-4BA9-AFB6-359C4F15721B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3C365D6D-3112-4BA9-AFB6-359C4F15721B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BD49B7A4-DCFD-4897-AE77-4BFA24CD5E40}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BD49B7A4-DCFD-4897-AE77-4BFA24CD5E40}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BD49B7A4-DCFD-4897-AE77-4BFA24CD5E40}.CoreDebug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BD49B7A4-DCFD-4897-AE77-4BFA24CD5E40}.CoreDebug|Any CPU.Build.0 = Debug|Any CPU
+		{BD49B7A4-DCFD-4897-AE77-4BFA24CD5E40}.CoreRelease|Any CPU.ActiveCfg = Debug|Any CPU
+		{BD49B7A4-DCFD-4897-AE77-4BFA24CD5E40}.CoreRelease|Any CPU.Build.0 = Debug|Any CPU
+		{BD49B7A4-DCFD-4897-AE77-4BFA24CD5E40}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BD49B7A4-DCFD-4897-AE77-4BFA24CD5E40}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -203,6 +223,7 @@ Global
 		{2FE642A4-A475-43CB-9B25-3986FE15CBD0} = {A0095379-E196-4179-B093-CD0B09721BE4}
 		{C0FD4943-55F0-4AF9-A3EA-31EB71FED2C8} = {6CCEFD1B-2C07-439B-980F-541F8F92FEA0}
 		{E6C265A5-BD88-4C12-821F-CF505D1DCB76} = {C0FD4943-55F0-4AF9-A3EA-31EB71FED2C8}
+		{BD49B7A4-DCFD-4897-AE77-4BFA24CD5E40} = {A0095379-E196-4179-B093-CD0B09721BE4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {DDB32B21-0D34-4C92-894C-BB39BE1BC4F7}

--- a/Tests/FiftyOne.Did.Tests/FiftyOne.Did.Tests.csproj
+++ b/Tests/FiftyOne.Did.Tests/FiftyOne.Did.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <AssemblyName>FiftyOne.Did.Tests</AssemblyName>
+    <RootNamespace>FiftyOne.Did.Tests</RootNamespace>
+    <Platforms>AnyCPU</Platforms>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\FiftyOne.Did\FiftyOne.Did.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/FiftyOne.Did.Tests/FodIdTests.cs
+++ b/Tests/FiftyOne.Did.Tests/FodIdTests.cs
@@ -1,0 +1,339 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+using FiftyOne.Did.Model;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Owid.Client;
+using Owid.Client.Model;
+using System;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+
+namespace FiftyOne.Did.Tests
+{
+    /// <summary>
+    /// Tests for <see cref="FodId"/>.
+    /// </summary>
+    [TestClass]
+    public class FodIdTests
+    {
+        private const string TestDomain = "51degrees.com";
+
+        private static readonly byte[] CanonicalHash = Enumerable
+            .Range(0, FodId.HashLength)
+            .Select(i => (byte)(0x20 + i))
+            .ToArray();
+
+        private const byte CanonicalFlags = 0b1010_0101;
+        private const uint CanonicalLicenseId = 0x12345678u;
+
+        private string PublicPem = string.Empty;
+        private string PrivatePem = string.Empty;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            using var crypto = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+            PublicPem = new string(PemEncoding.Write(
+                "PUBLIC KEY", crypto.ExportSubjectPublicKeyInfo()));
+            PrivatePem = new string(PemEncoding.Write(
+                "PRIVATE KEY", crypto.ExportPkcs8PrivateKey()));
+        }
+
+        /// <summary>
+        /// A canonical 37-byte 51Did payload with flags = 0xA5,
+        /// licenseId = 0x12345678 (little-endian), and a stable 32-byte hash
+        /// (0x20..0x3F). All field-level assertions key off these values.
+        /// </summary>
+        private static byte[] CanonicalPayload()
+        {
+            var payload = new byte[FodId.PayloadLength];
+            payload[FodId.FlagsOffset] = CanonicalFlags;
+            // Little-endian: low byte first
+            payload[FodId.LicenseIdOffset + 0] = 0x78;
+            payload[FodId.LicenseIdOffset + 1] = 0x56;
+            payload[FodId.LicenseIdOffset + 2] = 0x34;
+            payload[FodId.LicenseIdOffset + 3] = 0x12;
+            Array.Copy(CanonicalHash, 0, payload, FodId.HashOffset, FodId.HashLength);
+            return payload;
+        }
+
+        /// <summary>
+        /// Create and sign a real OWID with the given payload using a freshly
+        /// generated ECDsa P-256 key pair.
+        /// </summary>
+        private Owid.Client.Model.Owid SignedOwid(byte[] payload)
+        {
+            using var crypto = ECDsa.Create();
+            crypto.ImportFromPem(PrivatePem);
+            var creator = new Creator(TestDomain, crypto);
+            var owid = new Owid.Client.Model.Owid
+            {
+                Date = DateTime.UtcNow,
+                Payload = payload,
+            };
+            creator.Sign(owid);
+            return owid;
+        }
+
+        private string SignedOwidBase64(byte[] payload) =>
+            SignedOwid(payload).AsBase64();
+
+        [TestMethod]
+        public void Constants_AreInternallyConsistent()
+        {
+            // Guards against someone changing one offset/length constant
+            // without updating the others. The MSTEST0032 analyzer sees these
+            // as constant-folded so flags them — suppress locally.
+#pragma warning disable MSTEST0032
+            Assert.AreEqual(
+                FodId.HashOffset + FodId.HashLength,
+                FodId.PayloadLength);
+            Assert.AreEqual(
+                FodId.LicenseIdOffset + FodId.LicenseIdLength,
+                FodId.HashOffset);
+#pragma warning restore MSTEST0032
+        }
+
+        [TestMethod]
+        public void FodId_IsAnOwid()
+        {
+            var fodId = new FodId(SignedOwidBase64(CanonicalPayload()));
+
+            Assert.IsInstanceOfType<Owid.Client.Model.Owid>(fodId);
+        }
+
+        [TestMethod]
+        public void Constructor_FromBase64_UnpacksAllThreeFields()
+        {
+            var base64 = SignedOwidBase64(CanonicalPayload());
+
+            var fodId = new FodId(base64);
+
+            Assert.AreEqual(CanonicalFlags, fodId.Flags);
+            Assert.AreEqual(CanonicalLicenseId, fodId.LicenseId);
+            CollectionAssert.AreEqual(CanonicalHash, fodId.Hash);
+            Assert.AreEqual(TestDomain, fodId.Domain);
+        }
+
+        [TestMethod]
+        public void Constructor_FromBytes_UnpacksAllThreeFields()
+        {
+            var base64 = SignedOwidBase64(CanonicalPayload());
+            var bytes = Convert.FromBase64String(base64);
+
+            var fodId = new FodId(bytes);
+
+            Assert.AreEqual(CanonicalFlags, fodId.Flags);
+            Assert.AreEqual(CanonicalLicenseId, fodId.LicenseId);
+            CollectionAssert.AreEqual(CanonicalHash, fodId.Hash);
+            Assert.AreEqual(TestDomain, fodId.Domain);
+        }
+
+        [TestMethod]
+        public void Constructor_FromOwid_UnpacksAllThreeFields()
+        {
+            var owid = SignedOwid(CanonicalPayload());
+
+            var fodId = new FodId(owid);
+
+            Assert.AreEqual(CanonicalFlags, fodId.Flags);
+            Assert.AreEqual(CanonicalLicenseId, fodId.LicenseId);
+            CollectionAssert.AreEqual(CanonicalHash, fodId.Hash);
+            Assert.AreEqual(owid.Domain, fodId.Domain);
+            Assert.AreEqual(owid.Date, fodId.Date);
+            Assert.AreEqual(owid.Version, fodId.Version);
+            // Payload and Signature are reference-copied to avoid re-parsing.
+            Assert.AreSame(owid.Payload, fodId.Payload);
+            Assert.AreSame(owid.Signature, fodId.Signature);
+        }
+
+        [TestMethod]
+        public void Constructor_NullOwid_Throws()
+        {
+            Assert.ThrowsExactly<ArgumentNullException>(
+                () => new FodId((Owid.Client.Model.Owid)null!));
+        }
+
+        [TestMethod]
+        public void LicenseId_IsLittleEndian()
+        {
+            var payload = CanonicalPayload();
+            // 0x01 0x00 0x00 0x00 little-endian -> 1
+            payload[FodId.LicenseIdOffset + 0] = 0x01;
+            payload[FodId.LicenseIdOffset + 1] = 0x00;
+            payload[FodId.LicenseIdOffset + 2] = 0x00;
+            payload[FodId.LicenseIdOffset + 3] = 0x00;
+
+            var fodId = new FodId(SignedOwidBase64(payload));
+
+            Assert.AreEqual(1u, fodId.LicenseId);
+        }
+
+        [TestMethod]
+        public void LicenseId_MaxValue_IsLittleEndian()
+        {
+            var payload = CanonicalPayload();
+            payload[FodId.LicenseIdOffset + 0] = 0xFF;
+            payload[FodId.LicenseIdOffset + 1] = 0xFF;
+            payload[FodId.LicenseIdOffset + 2] = 0xFF;
+            payload[FodId.LicenseIdOffset + 3] = 0xFF;
+
+            var fodId = new FodId(SignedOwidBase64(payload));
+
+            Assert.AreEqual(uint.MaxValue, fodId.LicenseId);
+        }
+
+        [TestMethod]
+        public void LicenseId_HighBitSet_StaysUnsigned()
+        {
+            var payload = CanonicalPayload();
+            // 0x80000000 little-endian: 00 00 00 80
+            payload[FodId.LicenseIdOffset + 0] = 0x00;
+            payload[FodId.LicenseIdOffset + 1] = 0x00;
+            payload[FodId.LicenseIdOffset + 2] = 0x00;
+            payload[FodId.LicenseIdOffset + 3] = 0x80;
+
+            var fodId = new FodId(SignedOwidBase64(payload));
+
+            Assert.AreEqual(0x8000_0000u, fodId.LicenseId);
+        }
+
+        [TestMethod]
+        public void Flags_ZeroValue_Exposed()
+        {
+            var payload = CanonicalPayload();
+            payload[FodId.FlagsOffset] = 0x00;
+
+            var fodId = new FodId(SignedOwidBase64(payload));
+
+            Assert.AreEqual(0x00, fodId.Flags);
+        }
+
+        [TestMethod]
+        public void Flags_AllBitsSet_Exposed()
+        {
+            var payload = CanonicalPayload();
+            payload[FodId.FlagsOffset] = 0xFF;
+
+            var fodId = new FodId(SignedOwidBase64(payload));
+
+            Assert.AreEqual(0xFF, fodId.Flags);
+        }
+
+        [TestMethod]
+        public void Hash_IsDefensiveCopy()
+        {
+            var fodId = new FodId(SignedOwidBase64(CanonicalPayload()));
+
+            fodId.Hash[0] = 0x00;
+            fodId.Hash[FodId.HashLength - 1] = 0x00;
+
+            // The inherited Payload bytes must not have been mutated.
+            Assert.AreEqual(CanonicalHash[0], fodId.Payload[FodId.HashOffset]);
+            Assert.AreEqual(
+                CanonicalHash[FodId.HashLength - 1],
+                fodId.Payload[FodId.HashOffset + FodId.HashLength - 1]);
+        }
+
+        [TestMethod]
+        public void Constructor_PayloadOneByteShort_Throws()
+        {
+            // 36 bytes — one short of the minimum 37.
+            var base64 = SignedOwidBase64(new byte[FodId.PayloadLength - 1]);
+
+            Assert.ThrowsExactly<ArgumentException>(() => new FodId(base64));
+        }
+
+        [TestMethod]
+        public void Constructor_PayloadEmpty_Throws()
+        {
+            var base64 = SignedOwidBase64(Array.Empty<byte>());
+
+            Assert.ThrowsExactly<ArgumentException>(() => new FodId(base64));
+        }
+
+        [TestMethod]
+        public void Constructor_NullBase64_Throws()
+        {
+            Assert.ThrowsExactly<ArgumentNullException>(
+                () => new FodId((string)null!));
+        }
+
+        [TestMethod]
+        public void Constructor_NullBuffer_Throws()
+        {
+            Assert.ThrowsExactly<ArgumentNullException>(
+                () => new FodId((byte[])null!));
+        }
+
+        [TestMethod]
+        public void Constructor_InvalidBase64_Throws()
+        {
+            Assert.ThrowsExactly<FormatException>(
+                () => new FodId("This is not valid Base64!@#$"));
+        }
+
+        [TestMethod]
+        public void Constructor_PayloadLargerThanSpec_UsesFirst37Bytes()
+        {
+            // Build a 64-byte payload whose first 37 bytes match canonical;
+            // remaining bytes are 0xCC and should be ignored.
+            var payload = new byte[64];
+            Array.Copy(CanonicalPayload(), payload, FodId.PayloadLength);
+            for (int i = FodId.PayloadLength; i < payload.Length; i++)
+            {
+                payload[i] = 0xCC;
+            }
+
+            var fodId = new FodId(SignedOwidBase64(payload));
+
+            Assert.AreEqual(CanonicalFlags, fodId.Flags);
+            Assert.AreEqual(CanonicalLicenseId, fodId.LicenseId);
+            CollectionAssert.AreEqual(CanonicalHash, fodId.Hash);
+            Assert.AreEqual(FodId.HashLength, fodId.Hash.Length);
+        }
+
+        [TestMethod]
+        public async Task FodId_IsCryptographicallyVerifiable()
+        {
+            var fodId = new FodId(SignedOwidBase64(CanonicalPayload()));
+
+            using var verifyKey = ECDsa.Create();
+            verifyKey.ImportFromPem(PublicPem);
+            Assert.IsTrue(await fodId.VerifyAsync(verifyKey));
+        }
+
+        [TestMethod]
+        public void Base64Roundtrip_PreservesAllFields()
+        {
+            var fodId1 = new FodId(SignedOwidBase64(CanonicalPayload()));
+            var fodId2 = new FodId(fodId1.AsBase64());
+
+            Assert.AreEqual(fodId1.Flags, fodId2.Flags);
+            Assert.AreEqual(fodId1.LicenseId, fodId2.LicenseId);
+            CollectionAssert.AreEqual(fodId1.Hash, fodId2.Hash);
+            Assert.AreEqual(fodId1.Domain, fodId2.Domain);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Hi Eugene,

Introduces a new self-contained NuGet package `FiftyOne.Did` for parsing
51Degrees device identifier (51Did) values returned by the cloud service.
The package is single-assembly — Owid.Client source is compiled in
rather than referenced — so consumers see no transitive dependency.

A 51Did is an OWID envelope whose 37-byte payload encodes three fields,
matching the on-premise hasher in
`51Degrees/cloud/DiD/FiftyOne.DiD.OnPremise/Data/IdProbHashPayload.cs`
and the visual breakdown on the public 51Did inspector page:

| Offset | Length | Field      | Type                              |
|-------:|-------:|------------|-----------------------------------|
|      0 |      1 | Flags      | uint8 usage-flags bit-mask        |
|      1 |      4 | LicenseId  | uint32 (little-endian)            |
|      5 |     32 | Hash       | SHA-256 probabilistic identifier  |

## What it adds

- `FiftyOne.Did/` project, `PackageId = FiftyOne.Did`, EUPL-1.2.
- `FiftyOne.Did.Model.FodId : Owid.Client.Model.Owid` — three
  constructors (`string base64`, `byte[] buffer`, `Owid`) and three
  unpacked properties (`Flags`, `LicenseId`, `Hash`). Inherits from
  `Owid` so consumers retain full envelope access (`Domain`, `Date`,
  `Payload`, `Signature`, `VerifyAsync`, `AsBase64`).
- `Tests/FiftyOne.Did.Tests/` — 20 MSTest cases covering all three
  constructors, little-endian boundary values (1, MaxValue,
  high-bit-set), flags edge cases, defensive-copy semantics on
  `Hash`, payload too-short / empty / null / invalid-base64 error
  paths, payload-larger-than-spec uses first 37 bytes, base64
  round-trip, and that the inherited OWID remains cryptographically
  verifiable.
- `owid-dotnet` git submodule pointing at
  `SWAN-community/owid-dotnet @ main`.

## Why source-link instead of ProjectReference

The Owid.Client source is compiled directly into `FiftyOne.Did.dll`
via `<Compile Include="..\owid-dotnet\Owid.Client\**\*.cs" LinkBase="Owid" />`.
Two earlier approaches were considered and discarded:

- **PackageReference** to a published `Owid.Client` NuGet — blocked,
  SWAN-community has not published it.
- **Bundled DLL** alongside `FiftyOne.Did.dll` in the same package —
  works, but leaves consumers at risk of a duplicate-assembly
  collision if anything else in their graph ever pulls Owid.Client in
  separately.

Source-link produces a single self-contained `FiftyOne.Did.dll`
(~20KB) with no `<dependency>` entries in the nuspec. OWID types keep
their original `Owid.Client.Model` / `Owid.Client` namespaces because
linked-source preserves type identity.

## Naming conventions used

| Concept                  | Spelling      |
|--------------------------|---------------|
| Package id, assembly, namespace, folder | `FiftyOne.Did` (lowercase `d`) |
| Protocol / identifier name in code, error messages, docs | `51Did` (lowercase `d`) |
| Marketing material elsewhere | `51DiD` |
| Class for the parsed value | `FodId` (matches metadata) |

## A couple of judgement calls worth a look

1. **Fully-qualified `Owid.Client.Model.Owid`** throughout
   `FodId.cs` and the tests. Bare `Owid` clashes with the top-level
   `Owid` namespace and a using-alias `Owid = Owid.Client.Model.Owid`
   trips CS0576. No `OwidModel` alias either.
2. **EUPL-1.2 headers** on the new 51Degrees files; the linked
   Owid.Client files retain their original Apache 2.0 headers
   (Apache is compatible with EUPL).
3. **Solution change**: `Owid.Client.csproj` is deliberately NOT in
   any `.sln`, so the CI `^Project\(.*csproj` regex in
   `ci/build-package.ps1` does not pick it up and accidentally
   publish it under 51Degrees credentials.

## Test plan

- [ ] `dotnet test Tests/FiftyOne.Did.Tests` — expect 20/20 pass
- [ ] `dotnet pack FiftyOne.Did -c Release` — expect
      `FiftyOne.Did.1.0.0.nupkg` containing
      `lib/net8.0/FiftyOne.Did.dll` (~20KB, OWID compiled in) +
      `FiftyOne.Did.xml` + README + icon, empty `<dependencies>`
- [ ] CI picks the new csproj up from `FiftyOne.Pipeline.sln`
- [ ] No `Owid.Client.csproj` entry in any sln file we publish from

Thanks for the review,
James