### PR TITLE
FIX: WebRequestEvidenceService no longer surfaces benign client disconnects as warnings

### DIFF
--- a/Web Integration/FiftyOne.Pipeline.Web/Services/WebRequestEvidenceService.cs
+++ b/Web Integration/FiftyOne.Pipeline.Web/Services/WebRequestEvidenceService.cs
@@ -159,8 +159,23 @@ namespace FiftyOne.Pipeline.Web.Services
                             CheckAndAdd(flowData, evidenceKey, formValue.Value.ToString());
                         }
                     }
-                    catch (InvalidDataException e)
+                    catch (Exception e) when (e is InvalidDataException || e is IOException)
                     {
+                        // InvalidDataException - malformed form payload
+                        //   (existing case).
+                        // IOException        - client disconnected mid-body
+                        //   or Kestrel aborted a very slow upload via the
+                        //   MinRequestBodyDataRate guard. Kestrel surfaces
+                        //   both as BadHttpRequestException, which inherits
+                        //   from IOException, so we can catch it without
+                        //   taking a Microsoft.AspNetCore.Server.Kestrel.Core
+                        //   dependency (this library stays server-agnostic).
+                        // Both are benign client-side conditions, not
+                        // server-side faults, so they are logged at
+                        // Information rather than escaping to the outer
+                        // catch where they would be logged at Warning and
+                        // surface as ExceptionTelemetry in App Insights.
+                        // See https://github.com/51Degrees/pipeline-dotnet/issues/298
                         _logger.LogInformation(e,
                             Messages.MessageInvalidForm);
                     }

--- a/Web Integration/Tests/FiftyOne.Pipeline.Web.Tests/WebRequestEvidenceServiceTest.cs
+++ b/Web Integration/Tests/FiftyOne.Pipeline.Web.Tests/WebRequestEvidenceServiceTest.cs
@@ -357,7 +357,44 @@ namespace FiftyOne.Pipeline.Web.Tests
             _request.SetupGet(r => r.Form).Throws(new InvalidDataException());
             // Check that this does not throw an exception.
             _service.AddEvidenceFromRequest(_flowData.Object, _request.Object);
-            
+
+        }
+
+        /// <summary>
+        /// Regression test for issue #298.
+        ///
+        /// When the client disconnects mid-POST, the access to
+        /// <see cref="HttpRequest.Form"/> throws an
+        /// <see cref="IOException"/> -- Kestrel's
+        /// <c>BadHttpRequestException</c> inherits from it. Pre-fix, the
+        /// inner catch only handled <see cref="InvalidDataException"/>
+        /// so the IOException escaped to the outer general catch and
+        /// was logged at Warning level, surfacing as
+        /// ExceptionTelemetry in App Insights. Post-fix the inner
+        /// catch covers IOException too and the service swallows it
+        /// silently.
+        /// </summary>
+        [TestMethod]
+        public void WebRequestEvidenceService_BenignClientDisconnect_DoesNotThrow()
+        {
+            _request.SetupGet(r => r.Form).Throws(
+                new IOException("Unexpected end of request content."));
+            _service.AddEvidenceFromRequest(_flowData.Object, _request.Object);
+        }
+
+        /// <summary>
+        /// As above but for the <c>MinRequestBodyDataRate</c> abort,
+        /// which Kestrel surfaces with the same exception shape but a
+        /// different message string.
+        /// </summary>
+        [TestMethod]
+        public void WebRequestEvidenceService_BenignSlowUpload_DoesNotThrow()
+        {
+            _request.SetupGet(r => r.Form).Throws(
+                new IOException(
+                    "Reading the request body timed out due to data " +
+                    "arriving too slowly. See MinRequestBodyDataRate."));
+            _service.AddEvidenceFromRequest(_flowData.Object, _request.Object);
         }
 
         /// <summary>


### PR DESCRIPTION
Closes #298.

## Problem

`WebRequestEvidenceService.AddEvidenceFromRequest` surfaces benign client-side conditions as **Warning-level exception telemetry**. When a client disconnects mid-POST or when Kestrel aborts a very slow upload via the `MinRequestBodyDataRate` guard, the access to `httpRequest.Form` throws `Microsoft.AspNetCore.Server.Kestrel.Core.BadHttpRequestException`. The form-reading block only caught `InvalidDataException`:

```csharp
catch (InvalidDataException e)
{
    _logger.LogInformation(e, Messages.MessageInvalidForm);
}
```

`BadHttpRequestException` inherits from `IOException`, not `InvalidDataException`, so it missed the inner catch, escaped to the outer general catch, and was logged at Warning. ApplicationInsights' `ILogger` integration captures Warning + exception payload as `ExceptionTelemetry`, which is why this dominates the exception view for consumers of `FiftyOne.Pipeline.Web`.

Production evidence from `51dWebsite` over the last 7 days: **610 hits**, bursty spike days of ~250+ (16 May -> 60, 17 -> 9, 18 -> 247, 19 -> 274, 20 -> 3, 21 -> 11, 22 -> 6). Same pattern as the original spike in 51Degrees/Website#401 (802 in a day vs avg 12).

## Fix

Widen the inner catch to cover `IOException` as well:

```csharp
catch (Exception e) when (e is InvalidDataException || e is IOException)
{
    _logger.LogInformation(e, Messages.MessageInvalidForm);
}
```

This catches `BadHttpRequestException` without taking a hard dependency on `Microsoft.AspNetCore.Server.Kestrel.Core` -- the library remains server-agnostic. The downgrade to `LogInformation` matches the existing handling for the malformed-form case; neither is a server-side failure and neither warrants Warning-level telemetry. The exception is still logged at Information so it's recoverable from the log stream -- only the telemetry severity changes.

## Alternatives considered

- **Reference Kestrel and catch `BadHttpRequestException` by type.** Rejected: pulls in `Microsoft.AspNetCore.Server.Kestrel.Core` for a single catch.
- **Catch `Exception` and log at Information.** Rejected: would swallow genuine server-side bugs in `AddEvidenceFromRequest` and make them invisible. The `IOException` filter is the narrowest predicate that covers the benign cases without that risk.
- **App Insights `ITelemetryProcessor` on the consumer side.** That's the short-term workaround for 51Degrees/Website#401 while this PR is in flight; fixing it upstream benefits every consumer.

## Tests

Two new regression tests cover the two known Kestrel message strings:

- `WebRequestEvidenceService_BenignClientDisconnect_DoesNotThrow` -- "Unexpected end of request content."
- `WebRequestEvidenceService_BenignSlowUpload_DoesNotThrow` -- "Reading the request body timed out due to data arriving too slowly. See MinRequestBodyDataRate."

Both mock `HttpRequest.Form` throwing `IOException` and assert that `AddEvidenceFromRequest` returns without throwing. The pre-existing `WebRequestEvidenceService_InvalidForm` test (which covers the `InvalidDataException` branch) still passes.

```
dotnet test "Web Integration/Tests/FiftyOne.Pipeline.Web.Tests/FiftyOne.Pipeline.Web.Tests.csproj" \
  --filter "FullyQualifiedName~WebRequestEvidenceService"
Passed!  - Failed: 0, Passed: 20, Skipped: 0, Total: 20
```

## Downstream

51Degrees/Website#401 will close once this is published to NuGet and the website picks up the new version (currently on `FiftyOne.Pipeline.Web 4.5.36`).
