### PR TITLE
FiftyOne.Did: clarify identifier (wrapper) vs probabilistic value (payload)

### DIFF
--- a/FiftyOne.Did/FiftyOne.Did.csproj
+++ b/FiftyOne.Did/FiftyOne.Did.csproj
@@ -14,7 +14,7 @@
     <!-- NuGet package properties -->
     <PackageId>FiftyOne.Did</PackageId>
     <Title>51Degrees Device Identifier (51Did) parser</Title>
-    <PackageDescription>Parses a 51Degrees device identifier (51Did) value as returned by the 51Degrees Cloud service. The 51Did is an OWID envelope whose payload encodes a 1-byte usage flags bit-mask, a 4-byte little-endian License Id, and a 32-byte SHA-256 probabilistic identifier hash. The FodId type inherits from Owid.Client.Model.Owid (SWAN-community/owid-dotnet) and unpacks those three payload fields.</PackageDescription>
+    <PackageDescription>Parses the 51Degrees device identifier (51Did) returned by the 51Degrees Cloud service. The 51Did is an OWID envelope (the identifier) whose payload carries a 1-byte usage flags bit-mask, a 4-byte little-endian License Id, and a 32-byte SHA-256 probabilistic value. Compare probabilistic values, never full identifiers: two 51Dids for the same device share the same value even though their envelopes differ on every issue. The FodId type inherits from Owid.Client.Model.Owid (SWAN-community/owid-dotnet) and unpacks those three payload fields.</PackageDescription>
     <Authors>51Degrees Engineering</Authors>
     <PackageLicenseExpression>EUPL-1.2</PackageLicenseExpression>
     <PackageIconUrl>https://51degrees.com/portals/0/Logos/Square%20Logo.png?width=64</PackageIconUrl>
@@ -23,7 +23,7 @@
     <RepositoryUrl>https://github.com/51Degrees/pipeline-dotnet</RepositoryUrl>
     <PackageIcon>51d-logo.png</PackageIcon>
     <PackageProjectUrl>https://51degrees.com</PackageProjectUrl>
-    <Description>Parses a 51Degrees device identifier (51Did) value as returned by the 51Degrees Cloud service.</Description>
+    <Description>Parses the 51Degrees device identifier (51Did) returned by the 51Degrees Cloud service.</Description>
     <RepositoryType>git</RepositoryType>
     <NeutralLanguage>en</NeutralLanguage>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/FiftyOne.Did/Model/FodId.cs
+++ b/FiftyOne.Did/Model/FodId.cs
@@ -27,9 +27,18 @@ namespace FiftyOne.Did.Model
     /// <summary>
     /// An OWID whose payload encodes the three fields of a 51Did: a 1-byte
     /// usage flags bitmask, a 4-byte little-endian License Id, and the
-    /// 32-byte SHA-256 probabilistic identifier hash.
+    /// 32-byte SHA-256 probabilistic value.
     /// </summary>
     /// <remarks>
+    /// <para>
+    /// Terminology. The 51Did itself (this OWID envelope) is the
+    /// identifier. The 32-byte SHA-256 hash inside the payload is the
+    /// probabilistic value carried by that identifier; two responses for
+    /// the same device + IP + usage share the same probabilistic value
+    /// but differ at the byte level because the envelope embeds a fresh
+    /// date and signature on each call. Compare probabilistic values,
+    /// never full identifiers.
+    /// </para>
     /// <para>
     /// Payload layout (37 bytes):
     /// </para>
@@ -93,7 +102,13 @@ namespace FiftyOne.Did.Model
         public uint LicenseId { get; private set; }
 
         /// <summary>
-        /// The 32-byte SHA-256 probabilistic identifier hash from the payload.
+        /// The 32-byte SHA-256 probabilistic value from the payload.
+        /// This is the stable field for comparing two 51Did identifiers:
+        /// two identifiers for the same device + IP + usage share the
+        /// same probabilistic value even though their wrapping envelopes
+        /// (date, signature) differ on every issue. Treat as the cache /
+        /// dedup key. SHA-256 is the underlying hash function; the
+        /// property is named Hash to reflect that implementation detail.
         /// </summary>
         public byte[] Hash { get; private set; } = Array.Empty<byte>();
 

--- a/FiftyOne.Did/README.md
+++ b/FiftyOne.Did/README.md
@@ -1,21 +1,42 @@
 # FiftyOne.Did
 
-Strongly-typed .NET parser for the 51Did (51Degrees device identifier) value
+Strongly-typed .NET parser for the 51Did (51Degrees device identifier)
 returned by the 51Degrees Cloud service.
 
-A 51Did is an OWID envelope whose payload encodes three fields:
+## Terminology
 
-| Offset | Length | Field      | Type                              |
-|-------:|-------:|------------|-----------------------------------|
-|      0 |      1 | Flags      | uint8 usage-flags bit-mask        |
-|      1 |      4 | LicenseId  | uint32 (little-endian)            |
-|      5 |     32 | Hash       | SHA-256 probabilistic identifier  |
+The 51Did has two layers. The wording below treats them as distinct.
+
+- The **51Did** is the **identifier**. The whole base64 OWID envelope
+  (version, domain, date, payload, signature). It changes byte-for-byte
+  every time the cloud issues one, even for the same inputs, because
+  the date and signature change with each call.
+- The **probabilistic value** is one of the fields *inside* the payload
+  (a 32-byte SHA-256 hash). It is stable across reissues for the same
+  device + IP + usage: if two 51Dids were issued for the same inputs,
+  their probabilistic values are equal even though the wrapping
+  identifiers differ.
+
+Comparing two browsers means comparing the probabilistic values
+carried inside their identifiers, never the identifiers themselves.
+Calling either layer "the identifier" without qualification leads to
+incorrect comparisons; calling the inner field "the probabilistic
+identifier" is the same conflation in a different costume.
+
+## Payload layout
+
+| Offset | Length | Field      | Type                                  |
+|-------:|-------:|------------|---------------------------------------|
+|      0 |      1 | Flags      | uint8 usage-flags bit-mask            |
+|      1 |      4 | LicenseId  | uint32 (little-endian)                |
+|      5 |     32 | Hash       | 32 bytes, SHA-256 probabilistic value |
 
 `FodId` inherits from `Owid.Client.Model.Owid` (see
 [SWAN-community/owid-dotnet](https://github.com/SWAN-community/owid-dotnet)),
 so a `FodId` instance behaves as an OWID for all OWID-level concerns
-(domain, date, payload bytes, signature, base64 round-tripping) and adds
-strongly-typed accessors for the three 51Did payload fields on top.
+(domain, date, payload bytes, signature, base64 round-tripping) and
+adds strongly-typed accessors for the three 51Did payload fields on
+top.
 
 ## Usage
 
@@ -26,7 +47,7 @@ var fodId = new FodId(base64FromCloudService);
 
 byte    flags     = fodId.Flags;
 uint    licenseId = fodId.LicenseId;
-byte[]  hash      = fodId.Hash;        // 32 bytes
+byte[]  hash      = fodId.Hash;        // 32-byte probabilistic value
 
 // Inherited OWID-level fields.
 string   domain   = fodId.Domain;
@@ -37,17 +58,41 @@ bool     verified = await fodId.VerifyAsync(publicKey);
 string   roundTrip = fodId.AsBase64();
 ```
 
+## Comparing two 51Dids
+
+```csharp
+var a = new FodId(idprobglobalA);
+var b = new FodId(idprobglobalB);
+
+// Wrapper bytes (Domain, Date, Signature) ARE different; the
+// identifier itself is not stable across reissues:
+bool sameDate = a.Date == b.Date;                           // false
+bool sameSig  = a.Signature.SequenceEqual(b.Signature);     // false
+
+// The probabilistic value inside the payload IS stable; this is
+// what you actually compare:
+bool sameValue = a.Hash.SequenceEqual(b.Hash);              // true
+```
+
+Use `FodId.Hash` as the cache / dedup key. The same value means the
+same browser instance under the same usage policy on the same License
+Key (for `idproblic`) or across all callers (for `idprobglobal`).
+
 ## Non-goals
 
-- **Signature verification on construction.** Constructing a `FodId` does
-  not check the signature. Call `VerifyAsync` (inherited from `Owid`) when
-  needed.
-- **Construction of new 51Dids.** This is a parser. New 51Dids are issued by
-  the 51Degrees cloud / on-premise hashing engines.
+- **Signature verification on construction.** Constructing a `FodId`
+  does not check the signature. Call `VerifyAsync` (inherited from
+  `Owid`) when needed.
+- **Construction of new 51Dids.** This is a parser. New 51Dids are
+  issued by the 51Degrees cloud / on-premise hashing engines.
 
 ## See also
 
-- `https://github.com/SWAN-community/owid-dotnet` — OWID envelope library this
-  package builds on.
-- The 51Did inspector page on `51degrees.com/developers/fodid-inspector` for
-  a visual breakdown of the same byte layout.
+- `https://github.com/SWAN-community/owid-dotnet`, OWID envelope
+  library this package builds on.
+- The [51Did inspector](https://51degrees.com/developers/51did-inspector)
+  on `51degrees.com` for a visual breakdown of the same byte layout,
+  with signature verification and a "Live 51d.es v3" sample.
+- The [51Did comparer](https://51degrees.com/developers/51did-comparer)
+  for a side-by-side, byte-by-byte comparison of two 51Dids that
+  highlights the wrapper-vs-value distinction in action.


### PR DESCRIPTION
The 51Did has two distinct layers and the `FiftyOne.Did` public-facing docs (README, package metadata, `FodId.Hash` XML doc) were treating them interchangeably. Consumers read "probabilistic identifier" on the `Hash` field and reach for byte-by-byte comparison of the full envelope, then conclude two responses for the same device are different.

## What changed

* **Terminology** named explicitly:
  - The **51Did** is the **identifier**, the whole base64 OWID envelope (version, domain, date, payload, signature). Changes byte-for-byte on every reissue.
  - The **probabilistic value** is the 32-byte SHA-256 hash inside the payload. Stable across reissues for the same device + IP + usage.
* `FodId.cs` class XML-doc gains a Terminology paragraph. The `Hash` property doc spells out it IS the probabilistic value, that it is the stable comparison key, and that `Hash` is the property name only because SHA-256 is the implementation detail.
* `FiftyOne.Did.csproj` `PackageDescription` rewritten to lead with the distinction and the comparison rule. `Description` tightened to drop the redundant "value" after "identifier".
* `README.md` gets a Terminology section at the top, a `Comparing two 51Dids` section with a worked example, and the broken `/developers/fodid-inspector` link replaced with the correct `/developers/51did-inspector` plus a pointer to the new comparer page.

## API surface

**Unchanged.** Property names (`Flags`, `LicenseId`, `Hash`) all preserved, no behavioural change, no signature change. This is a docs / package-metadata change only, so it can ship in any patch release.

## Cross-references

- `51Degrees/documentation#150`, the same distinction in the developer docs.
- `51Degrees/Website feature/51did-comparer`, where "Probabilistic value" is now the canonical name in both the inspector and the comparer pages, and `/developers/51did-comparer` is the new side-by-side comparison page.

## Test plan

- [ ] Read the new `README.md` Terminology section, the wrapper / value distinction should be immediately clear.
- [ ] Walk through the `Comparing two 51Dids` code sample with the new comments, a reader following only the comments compares the right field.
- [ ] Verify the See-also link to `/developers/51did-inspector` resolves (was `/developers/fodid-inspector`, a 404).
- [ ] Re-pack the NuGet locally and confirm the new `PackageDescription` is what surfaces on nuget.org.