### PR TITLE
Align resource key environment variable and configurator links

### DIFF
--- a/Examples/CloudRequestEngine/GettingStarted/Program.cs
+++ b/Examples/CloudRequestEngine/GettingStarted/Program.cs
@@ -43,8 +43,11 @@ namespace GettingStarted
 
             var engine = new CloudRequestEngineBuilder(_loggerFactory, _httpClient)
                 .SetEndPoint("https://cloud.51degrees.com/api/v4/json")
-                // Obtain a resource key from https://configure.51degrees.com
-                .SetResourceKey("AQS5HKcyHJbECm6E10g")
+                // A resource key with the properties needed by the examples
+                // can be created at https://configure.51degrees.com/Wkqxf3Bs.
+                // The aligned 51DEGREES_RESOURCE_KEY environment variable is
+                // checked first, then the legacy RESOURCE_KEY variable.
+                .SetResourceKey(GetResourceKey())
                 .SetLazyLoading(cfg)
                 .Build();
                 
@@ -59,6 +62,28 @@ namespace GettingStarted
             }
 
             Console.ReadKey();
+        }
+
+        /// <summary>
+        /// Get the resource key to use for this example. The aligned
+        /// 51DEGREES_RESOURCE_KEY environment variable is checked first,
+        /// then the legacy RESOURCE_KEY variable. If neither is set then
+        /// the hard-coded key below is used, preserving the previous
+        /// behaviour of this example.
+        /// </summary>
+        private static string GetResourceKey()
+        {
+            var resourceKey =
+                Environment.GetEnvironmentVariable("51DEGREES_RESOURCE_KEY");
+            if (string.IsNullOrEmpty(resourceKey))
+            {
+                resourceKey = Environment.GetEnvironmentVariable("RESOURCE_KEY");
+            }
+            if (string.IsNullOrEmpty(resourceKey))
+            {
+                resourceKey = "AQS5HKcyHJbECm6E10g";
+            }
+            return resourceKey;
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ If you want examples that demonstrate how to use 51Degrees products such as devi
 | ResultCaching                             | Shows how the result caching feature works. |
 | UsageSharing                              | Shows how to share usage with 51Degrees. This helps us to keep our products up to date and accurate. |
 
+The CloudRequestEngine\GettingStarted example requires a resource key. It reads the aligned `51DEGREES_RESOURCE_KEY` environment variable first, then the legacy `RESOURCE_KEY` variable. A resource key with the free properties used by the examples can be created at https://configure.51degrees.com/Wkqxf3Bs.
+
 ## Tests
 
 - **FiftyOne.Pipeline.CloudRequestEngine.Tests** - Tests for the CloudRequestEngine and builder.


### PR DESCRIPTION
## Summary

This change aligns the cloud example with the convention shared across 51Degrees repositories.

- The CloudRequestEngine GettingStarted example now reads the resource key from the `51DEGREES_RESOURCE_KEY` environment variable first, then the legacy `RESOURCE_KEY` variable, falling back to the previous hard coded key so existing behaviour and the example test are preserved.
- The example comment and README reference the shared configurator link https://configure.51degrees.com/Wkqxf3Bs, which selects the free tier properties used by the examples.

## Notes

- The library builder API is unchanged, the resource key is still supplied programmatically with SetResourceKey.
- GitHub workflow secret references are unchanged. An accompanying issue advises on the aligned secret naming.
- The aligned name starts with a digit, which POSIX shells do not accept in plain assignments. On Linux and macOS set it with the env command.
