### PR TITLE
Add UTM parameters to 51degrees.com links

### DIFF
--- a/.github/workflows/utm-link-lint.yml
+++ b/.github/workflows/utm-link-lint.yml
@@ -1,0 +1,25 @@
+name: UTM link lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  utm-link-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout common-ci
+        uses: actions/checkout@v4
+        with:
+          repository: 51Degrees/common-ci
+          path: utm-lint-common-ci
+
+      - name: Lint 51degrees.com links
+        shell: pwsh
+        run: ./utm-lint-common-ci/scripts/utm-lint.ps1 -RepoRoot .

--- a/Examples/CloudRequestEngine/GettingStarted/Program.cs
+++ b/Examples/CloudRequestEngine/GettingStarted/Program.cs
@@ -44,7 +44,7 @@ namespace GettingStarted
             var engine = new CloudRequestEngineBuilder(_loggerFactory, _httpClient)
                 .SetEndPoint("https://cloud.51degrees.com/api/v4/json")
                 // A resource key with the properties needed by the examples
-                // can be created at https://configure.51degrees.com/Wkqxf3Bs.
+                // can be created at https://configure.51degrees.com/Wkqxf3Bs?utm_source=code&utm_medium=example&utm_campaign=pipeline-dotnet&utm_content=examples-cloudrequestengine-gettingstarted-program.cs&utm_term=main.
                 // The aligned 51DEGREES_RESOURCE_KEY environment variable is
                 // checked first, then the legacy RESOURCE_KEY variable.
                 .SetResourceKey(GetResourceKey())

--- a/Examples/ResultCaching/Program.cs
+++ b/Examples/ResultCaching/Program.cs
@@ -34,7 +34,7 @@ using System.Diagnostics;
 /// 
 /// If you want to know more about how result caching works, a complete
 /// explanation can be found in the 
-/// [documentation](https://51degrees.com/documentation/_features__result_caching.html).
+/// [documentation](https://51degrees.com/documentation/_features__result_caching.html?utm_source=code&amp;utm_medium=example&amp;utm_campaign=pipeline-dotnet&amp;utm_content=examples-resultcaching-program.cs&amp;utm_term=header).
 /// 
 /// This example is available in full on [GitHub](https://github.com/51Degrees/pipeline-dotnet/blob/master/Examples/ResultCaching/Program.cs).
 /// 

--- a/FiftyOne.Did.Cloud/FiftyOne.Did.Cloud.csproj
+++ b/FiftyOne.Did.Cloud/FiftyOne.Did.Cloud.csproj
@@ -19,7 +19,7 @@
     <PackageTags>51degrees,device-identification,did,pipeline,cloud,owid,51Did</PackageTags>
     <RepositoryUrl>https://github.com/51Degrees/pipeline-dotnet</RepositoryUrl>
     <PackageIcon>51d-logo.png</PackageIcon>
-    <PackageProjectUrl>https://51degrees.com</PackageProjectUrl>
+    <PackageProjectUrl>https://51degrees.com?utm_source=nuget&amp;utm_medium=package&amp;utm_campaign=pipeline-dotnet&amp;utm_content=fiftyone.did.cloud-fiftyone.did.cloud.csproj&amp;utm_term=packageprojecturl</PackageProjectUrl>
     <Description>Cloud device identification engine for 51Degrees Did. Enables local device identification processing using the 51Degrees Pipeline API with OWID client support.</Description>
     <RepositoryType>git</RepositoryType>
     <NeutralLanguage>en</NeutralLanguage>

--- a/FiftyOne.Did.Cloud/README.md
+++ b/FiftyOne.Did.Cloud/README.md
@@ -13,4 +13,4 @@ Requires a valid 51Degrees resource key for cloud API access.
 
 ## Links
 
-- [Documentation](https://51degrees.com/documentation)
+- [Documentation](https://51degrees.com/documentation?utm_source=github&utm_medium=readme&utm_campaign=pipeline-dotnet&utm_content=fiftyone.did.cloud-readme.md&utm_term=links)

--- a/FiftyOne.Did.Core/FiftyOne.Did.Core.csproj
+++ b/FiftyOne.Did.Core/FiftyOne.Did.Core.csproj
@@ -19,7 +19,7 @@
     <PackageTags>51degrees,device-identification,did,pipeline,core</PackageTags>
     <RepositoryUrl>https://github.com/51Degrees/pipeline-dotnet</RepositoryUrl>
     <PackageIcon>51d-logo.png</PackageIcon>
-    <PackageProjectUrl>https://51degrees.com</PackageProjectUrl>
+    <PackageProjectUrl>https://51degrees.com?utm_source=nuget&amp;utm_medium=package&amp;utm_campaign=pipeline-dotnet&amp;utm_content=fiftyone.did.core-fiftyone.did.core.csproj&amp;utm_term=packageprojecturl</PackageProjectUrl>
     <Description>Core library for 51Degrees Device Identification (Did). Provides foundational components and data structures for device identification within the 51Degrees Pipeline API.</Description>
     <RepositoryType>git</RepositoryType>
     <NeutralLanguage>en</NeutralLanguage>

--- a/FiftyOne.Did.Core/README.md
+++ b/FiftyOne.Did.Core/README.md
@@ -16,4 +16,4 @@ This is a shared dependency library. Most consumers should reference one of the 
 
 ## Links
 
-- [Documentation](https://51degrees.com/documentation)
+- [Documentation](https://51degrees.com/documentation?utm_source=github&utm_medium=readme&utm_campaign=pipeline-dotnet&utm_content=fiftyone.did.core-readme.md&utm_term=links)

--- a/FiftyOne.Did/FiftyOne.Did.csproj
+++ b/FiftyOne.Did/FiftyOne.Did.csproj
@@ -22,7 +22,7 @@
     <PackageTags>51degrees,51did,fodid,did,pipeline,owid</PackageTags>
     <RepositoryUrl>https://github.com/51Degrees/pipeline-dotnet</RepositoryUrl>
     <PackageIcon>51d-logo.png</PackageIcon>
-    <PackageProjectUrl>https://51degrees.com</PackageProjectUrl>
+    <PackageProjectUrl>https://51degrees.com?utm_source=nuget&amp;utm_medium=package&amp;utm_campaign=pipeline-dotnet&amp;utm_content=fiftyone.did-fiftyone.did.csproj&amp;utm_term=packageprojecturl</PackageProjectUrl>
     <Description>Parses the 51Degrees device identifier (51Did) returned by the 51Degrees Cloud service.</Description>
     <RepositoryType>git</RepositoryType>
     <NeutralLanguage>en</NeutralLanguage>

--- a/FiftyOne.Did/README.md
+++ b/FiftyOne.Did/README.md
@@ -90,9 +90,9 @@ Key (for `idproblic`) or across all callers (for `idprobglobal`).
 
 - `https://github.com/SWAN-community/owid-dotnet`, OWID envelope
   library this package builds on.
-- The [51Did inspector](https://51degrees.com/developers/51did-inspector)
+- The [51Did inspector](https://51degrees.com/developers/51did-inspector?utm_source=github&utm_medium=readme&utm_campaign=pipeline-dotnet&utm_content=fiftyone.did-readme.md&utm_term=see-also)
   on `51degrees.com` for a visual breakdown of the same byte layout,
   with signature verification and a "Live 51d.es v3" sample.
-- The [51Did comparer](https://51degrees.com/developers/51did-comparer)
+- The [51Did comparer](https://51degrees.com/developers/51did-comparer?utm_source=github&utm_medium=readme&utm_campaign=pipeline-dotnet&utm_content=fiftyone.did-readme.md&utm_term=see-also)
   for a side-by-side, byte-by-byte comparison of two 51Dids that
   highlights the wrapper-vs-value distinction in action.

--- a/FiftyOne.Pipeline.CloudRequestEngine/FiftyOne.Pipeline.CloudRequestEngine.csproj
+++ b/FiftyOne.Pipeline.CloudRequestEngine/FiftyOne.Pipeline.CloudRequestEngine.csproj
@@ -21,7 +21,7 @@
 	  <RepositoryUrl>https://github.com/51Degrees/pipeline-dotnet</RepositoryUrl>
 	  <Description>The 51Degrees Pipeline API provides a fast, modern architecture for consuming real-time digital data services. This package contains a shared engine that is used to make requests to the 51Degrees cloud service on behalf of other data services such as device detection or location.</Description>
 	  <PackageIcon>51d-logo.png</PackageIcon>
-	  <PackageProjectUrl>https://51degrees.com</PackageProjectUrl>
+	  <PackageProjectUrl>https://51degrees.com?utm_source=nuget&amp;utm_medium=package&amp;utm_campaign=pipeline-dotnet&amp;utm_content=fiftyone.pipeline.cloudrequestengine-fiftyone.pipeline.cloudrequestengine.csproj&amp;utm_term=packageprojecturl</PackageProjectUrl>
 	  <RepositoryType>git</RepositoryType>
 	  <NeutralLanguage>en</NeutralLanguage>
 	  <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/FiftyOne.Pipeline.CloudRequestEngine/FlowElements/CloudPipelineBuilderBase.cs
+++ b/FiftyOne.Pipeline.CloudRequestEngine/FlowElements/CloudPipelineBuilderBase.cs
@@ -172,7 +172,7 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.FlowElements
 
         /// <summary>
         /// Set the resource key which will be used to query the cloud service.
-        /// Obtain a resource key @ https://configure.51degrees.com
+        /// Obtain a resource key @ https://configure.51degrees.com?utm_source=code&amp;utm_medium=comment&amp;utm_campaign=pipeline-dotnet&amp;utm_content=fiftyone.pipeline.cloudrequestengine-flowelements-cloudpipelinebuilderbase.cs&amp;utm_term=setresourcekey
         /// </summary>
         /// <param name="key">The resource key to use</param>
         /// <returns>This builder</returns>

--- a/FiftyOne.Pipeline.CloudRequestEngine/FlowElements/CloudRequestEngine.cs
+++ b/FiftyOne.Pipeline.CloudRequestEngine/FlowElements/CloudRequestEngine.cs
@@ -78,7 +78,7 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.FlowElements
             /// A resource key encapsulates details such as any license keys,
             /// the properties that should be returned and the domains that
             /// requests are permitted from. A new resource key can be
-            /// generated for free at https://configure.51degrees.com
+            /// generated for free at https://configure.51degrees.com?utm_source=code&amp;utm_medium=comment&amp;utm_campaign=pipeline-dotnet&amp;utm_content=fiftyone.pipeline.cloudrequestengine-flowelements-cloudrequestengine.cs&amp;utm_term=resourcekey
             /// </summary>
             public string ResourceKey;
 
@@ -143,7 +143,7 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.FlowElements
         /// A resource key encapsulates details such as any license keys,
         /// the properties that should be returned and the domains that
         /// requests are permitted from. A new resource key can be
-        /// generated for free at https://configure.51degrees.com
+        /// generated for free at https://configure.51degrees.com?utm_source=code&amp;utm_medium=comment&amp;utm_campaign=pipeline-dotnet&amp;utm_content=fiftyone.pipeline.cloudrequestengine-flowelements-cloudrequestengine.cs&amp;utm_term=cloudrequestengine
         /// </param>
         /// <param name="dataEndpoint">
         /// The URL for the cloud endpoint that will take the supplied

--- a/FiftyOne.Pipeline.CloudRequestEngine/Messages.resx
+++ b/FiftyOne.Pipeline.CloudRequestEngine/Messages.resx
@@ -136,10 +136,10 @@
     <value>The '{0}' did not process because the JSON response from the CloudRequestEngine was null or empty. This indicates that the cloud request failed.</value>
   </data>
   <data name="ExceptionFailedToLoadProperties" xml:space="preserve">
-    <value>Failed to load aspect properties for element '{0}'. This is because your resource key does not include access to any properties under '{0}'. For more details on resource keys, see our explainer: https://51degrees.com/documentation/_info__resource_keys.html</value>
+    <value>Failed to load aspect properties for element '{0}'. This is because your resource key does not include access to any properties under '{0}'. For more details on resource keys, see our explainer: https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&amp;utm_medium=comment&amp;utm_campaign=pipeline-dotnet&amp;utm_content=fiftyone.pipeline.cloudrequestengine-messages.resx&amp;utm_term=exceptionfailedtoloadproperties</value>
   </data>
   <data name="ExceptionResourceKeyNeeded" xml:space="preserve">
-    <value>A resource key is required to access the 51Degrees cloud service. Please use the 'SetResourceKey' method to supply your resource key. You can obtain one for free from https://configure.51degrees.com</value>
+    <value>A resource key is required to access the 51Degrees cloud service. Please use the 'SetResourceKey' method to supply your resource key. You can obtain one for free from https://configure.51degrees.com?utm_source=code&amp;utm_medium=comment&amp;utm_campaign=pipeline-dotnet&amp;utm_content=fiftyone.pipeline.cloudrequestengine-messages.resx&amp;utm_term=exceptionresourcekeyneeded</value>
   </data>
   <data name="ExceptionTaskCanceledRequest" xml:space="preserve">
     <value>Failed to send request. A TaskCanceledException was thrown. The likely cause of this would be a connection timeout.</value>

--- a/FiftyOne.Pipeline.Core/FiftyOne.Pipeline.Core.csproj
+++ b/FiftyOne.Pipeline.Core/FiftyOne.Pipeline.Core.csproj
@@ -21,7 +21,7 @@
 	  <PackageTags>51degrees,pipeline,data service</PackageTags>
 	  <RepositoryUrl>https://github.com/51Degrees/pipeline-dotnet</RepositoryUrl>
 	  <PackageIcon>51d-logo.png</PackageIcon>
-	  <PackageProjectUrl>https://51degrees.com</PackageProjectUrl>
+	  <PackageProjectUrl>https://51degrees.com?utm_source=nuget&amp;utm_medium=package&amp;utm_campaign=pipeline-dotnet&amp;utm_content=fiftyone.pipeline.core-fiftyone.pipeline.core.csproj&amp;utm_term=packageprojecturl</PackageProjectUrl>
 	  <Description>The 51Degrees Pipeline API provides a fast, modern architecture for consuming real-time digital data services. This package contains the core components of the Pipeline API.</Description>
 	  <RepositoryType>git</RepositoryType>
 	  <NeutralLanguage>en</NeutralLanguage>

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElement/FiftyOne.Pipeline.JavaScriptBuilder.csproj
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElement/FiftyOne.Pipeline.JavaScriptBuilder.csproj
@@ -26,7 +26,7 @@
     <PackageTags>51degrees,pipeline,data service</PackageTags>
     <RepositoryUrl>https://github.com/51Degrees/pipeline-dotnet</RepositoryUrl>
     <PackageIcon>51d-logo.png</PackageIcon>
-    <PackageProjectUrl>https://51degrees.com</PackageProjectUrl>
+    <PackageProjectUrl>https://51degrees.com?utm_source=nuget&amp;utm_medium=package&amp;utm_campaign=pipeline-dotnet&amp;utm_content=fiftyone.pipeline.elements-fiftyone.pipeline.javascriptbuilderelement-fiftyone.pipeline.javascriptbuilder.csproj&amp;utm_term=packageprojecturl</PackageProjectUrl>
     <Description>The 51Degrees Pipeline API provides a fast, modern architecture for consuming real-time digital data services. This package contains an element that produces JavaScript code used to access Pipeline results in client-side code and provide additional evidence that is not available from the initial request to the web server.</Description>
     <NeutralLanguage>en</NeutralLanguage>
     <RepositoryType>git</RepositoryType>

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElement/FlowElement/JavaScriptBuilderElementBuilder.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElement/FlowElement/JavaScriptBuilderElementBuilder.cs
@@ -95,7 +95,7 @@ namespace FiftyOne.Pipeline.JavaScriptBuilder.FlowElement
         /// processing in cookies.
         /// This can also be set per request, using the "query.fod-js-enable-cookies"
         /// evidence key.
-        /// For more details on personal data policy, see http://51degrees.com/terms/client-services-privacy-policy/
+        /// For more details on personal data policy, see https://51degrees.com/terms/client-services-privacy-policy/?utm_source=code&amp;utm_medium=comment&amp;utm_campaign=pipeline-dotnet&amp;utm_content=fiftyone.pipeline.elements-fiftyone.pipeline.javascriptbuilderelement-flowelement-javascriptbuilderelementbuilder.cs&amp;utm_term=setenablecookies
         /// </summary>
         /// <param name="enableCookies">Should enable cookies?</param>
         /// <returns></returns>

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JsonBuilderElement/FiftyOne.Pipeline.JsonBuilder.csproj
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JsonBuilderElement/FiftyOne.Pipeline.JsonBuilder.csproj
@@ -23,7 +23,7 @@
     <RepositoryType>git</RepositoryType>
     <NeutralLanguage>en</NeutralLanguage>
     <Description>The 51Degrees Pipeline API provides a fast, modern architecture for consuming real-time digital data services. This package contains an element that serializes all values in flowdata into a JSON formatted string.</Description>
-    <PackageProjectUrl>https://51degrees.com</PackageProjectUrl>
+    <PackageProjectUrl>https://51degrees.com?utm_source=nuget&amp;utm_medium=package&amp;utm_campaign=pipeline-dotnet&amp;utm_content=fiftyone.pipeline.elements-fiftyone.pipeline.jsonbuilderelement-fiftyone.pipeline.jsonbuilder.csproj&amp;utm_term=packageprojecturl</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JsonBuilderElement/Messages.resx
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JsonBuilderElement/Messages.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ExceptionSequenceNumberNotPresent" xml:space="preserve">
-    <value>The value for the ‘sequence’ parameter could not found. See https://51degrees.com/documentation/_info__error_messages.html#Sequence_value_not_found for more information.</value>
+    <value>The value for the ‘sequence’ parameter could not found. See https://51degrees.com/documentation/_info__error_messages.html?utm_source=code&amp;utm_medium=comment&amp;utm_campaign=pipeline-dotnet&amp;utm_content=fiftyone.pipeline.elements-fiftyone.pipeline.jsonbuilderelement-messages.resx&amp;utm_term=exceptionsequencenumbernotpresent#Sequence_value_not_found for more information.</value>
   </data>
 </root>

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.Translation/FiftyOne.Pipeline.Translation.csproj
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.Translation/FiftyOne.Pipeline.Translation.csproj
@@ -23,7 +23,7 @@
     <RepositoryType>git</RepositoryType>
     <NeutralLanguage>en</NeutralLanguage>
     <Description>The 51Degrees Pipeline API provides a fast, modern architecture for consuming real-time digital data services. This package contains an element that translates values from other engines into other languages.</Description>
-    <PackageProjectUrl>https://51degrees.com</PackageProjectUrl>
+    <PackageProjectUrl>https://51degrees.com?utm_source=nuget&amp;utm_medium=package&amp;utm_campaign=pipeline-dotnet&amp;utm_content=fiftyone.pipeline.elements-fiftyone.pipeline.translation-fiftyone.pipeline.translation.csproj&amp;utm_term=packageprojecturl</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 

--- a/FiftyOne.Pipeline.Engines.FiftyOne/Data/FiftyOneAspectPropertyMetaDataDefault.cs
+++ b/FiftyOne.Pipeline.Engines.FiftyOne/Data/FiftyOneAspectPropertyMetaDataDefault.cs
@@ -91,7 +91,7 @@ namespace FiftyOne.Pipeline.Engines.FiftyOne.Data
         /// </summary>
         /// <remarks>
         /// This is used by the 51Degrees Property Dictionary: 
-        /// https://51degrees.com/resources/property-dictionary and is 
+        /// https://51degrees.com/resources/property-dictionary?utm_source=code&amp;utm_medium=comment&amp;utm_campaign=pipeline-dotnet&amp;utm_content=fiftyone.pipeline.engines.fiftyone-data-fiftyoneaspectpropertymetadatadefault.cs&amp;utm_term=show and is 
         /// made available for customers should they wish to make use of it.
         /// </remarks>
         public bool Show { get; }
@@ -103,7 +103,7 @@ namespace FiftyOne.Pipeline.Engines.FiftyOne.Data
         /// </summary>
         /// <remarks>
         /// This is used by the 51Degrees Property Dictionary: 
-        /// https://51degrees.com/resources/property-dictionary and is 
+        /// https://51degrees.com/resources/property-dictionary?utm_source=code&amp;utm_medium=comment&amp;utm_campaign=pipeline-dotnet&amp;utm_content=fiftyone.pipeline.engines.fiftyone-data-fiftyoneaspectpropertymetadatadefault.cs&amp;utm_term=showvalues and is 
         /// made available for customers should they wish to make use of it.
         /// </remarks>
         public bool ShowValues { get; }

--- a/FiftyOne.Pipeline.Engines.FiftyOne/FiftyOne.Pipeline.Engines.FiftyOne.csproj
+++ b/FiftyOne.Pipeline.Engines.FiftyOne/FiftyOne.Pipeline.Engines.FiftyOne.csproj
@@ -21,7 +21,7 @@
 	  <RepositoryUrl>https://github.com/51Degrees/pipeline-dotnet</RepositoryUrl>
 	  <Description>The 51Degrees Pipeline API provides a fast, modern architecture for consuming real-time digital data services. This package contains base classes that provide functionality used by 51Degrees engines.</Description>
 	  <PackageIcon>51d-logo.png</PackageIcon>
-	  <PackageProjectUrl>https://51degrees.com</PackageProjectUrl>
+	  <PackageProjectUrl>https://51degrees.com?utm_source=nuget&amp;utm_medium=package&amp;utm_campaign=pipeline-dotnet&amp;utm_content=fiftyone.pipeline.engines.fiftyone-fiftyone.pipeline.engines.fiftyone.csproj&amp;utm_term=packageprojecturl</PackageProjectUrl>
 	  <RepositoryType>git</RepositoryType>
 	  <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/FiftyOne.Pipeline.Engines.FiftyOne/Messages.resx
+++ b/FiftyOne.Pipeline.Engines.FiftyOne/Messages.resx
@@ -133,7 +133,7 @@
     <value>Failed to increment usage sequence number</value>
   </data>
   <data name="MessageFailSequenceNumberParse" xml:space="preserve">
-    <value>The value for the ‘sequence’ parameter is not valid. See https://51degrees.com/documentation/_info__error_messages.html#Sequence_value_invalid for more information.</value>
+    <value>The value for the ‘sequence’ parameter is not valid. See https://51degrees.com/documentation/_info__error_messages.html?utm_source=code&amp;utm_medium=comment&amp;utm_campaign=pipeline-dotnet&amp;utm_content=fiftyone.pipeline.engines.fiftyone-messages.resx&amp;utm_term=messagefailsequencenumberparse#Sequence_value_invalid for more information.</value>
   </data>
   <data name="MessageFailSequenceNumberRetreive" xml:space="preserve">
     <value>Failed to retrieve sequence number</value>

--- a/FiftyOne.Pipeline.Engines.TestHelpers/FiftyOne.Pipeline.Engines.TestHelpers.csproj
+++ b/FiftyOne.Pipeline.Engines.TestHelpers/FiftyOne.Pipeline.Engines.TestHelpers.csproj
@@ -13,7 +13,7 @@
 	<Copyright>51Degrees Mobile Experts Limited</Copyright>
 	<PackageTags>51degrees,pipeline,data service</PackageTags>
 	<RepositoryUrl>https://github.com/51Degrees/pipeline-dotnet</RepositoryUrl>
-	<PackageProjectUrl>https://51degrees.com</PackageProjectUrl>
+	<PackageProjectUrl>https://51degrees.com?utm_source=nuget&amp;utm_medium=package&amp;utm_campaign=pipeline-dotnet&amp;utm_content=fiftyone.pipeline.engines.testhelpers-fiftyone.pipeline.engines.testhelpers.csproj&amp;utm_term=packageprojecturl</PackageProjectUrl>
 	<Description>The 51Degrees Pipeline API provides a fast, modern architecture for consuming real-time digital data services. The package contains helper classes to make writing unit tests easier when developing a custom engine using FiftyOne.Pipeline.Engines.</Description>
 	<PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/FiftyOne.Pipeline.Engines/FiftyOne.Pipeline.Engines.csproj
+++ b/FiftyOne.Pipeline.Engines/FiftyOne.Pipeline.Engines.csproj
@@ -21,7 +21,7 @@
 	  <RepositoryUrl>https://github.com/51Degrees/pipeline-dotnet</RepositoryUrl>
 	  <Description>The 51Degrees Pipeline API provides a fast, modern architecture for consuming real-time digital data services. This package contains base classes that implement the shared features available to engines - a specialized type of flow element.</Description>
 	  <PackageIcon>51d-logo.png</PackageIcon>
-	  <PackageProjectUrl>https://51degrees.com</PackageProjectUrl>
+	  <PackageProjectUrl>https://51degrees.com?utm_source=nuget&amp;utm_medium=package&amp;utm_campaign=pipeline-dotnet&amp;utm_content=fiftyone.pipeline.engines-fiftyone.pipeline.engines.csproj&amp;utm_term=packageprojecturl</PackageProjectUrl>
 	  <RepositoryType>git</RepositoryType>
 	  <NeutralLanguage>en</NeutralLanguage>
 	  <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/FiftyOne.Pipeline.Engines/Messages.resx
+++ b/FiftyOne.Pipeline.Engines/Messages.resx
@@ -181,13 +181,13 @@
     <value>Property '{0}' not found in data for element '{1}'. </value>
   </data>
   <data name="MissingPropertyMessageProductNotInCloudResource" xml:space="preserve">
-    <value>This is because your resource key does not include access to any properties under '{0}'. For more details on resource keys, see our explainer: https://51degrees.com/documentation/_info__resource_keys.html</value>
+    <value>This is because your resource key does not include access to any properties under '{0}'. For more details on resource keys, see our explainer: https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&amp;utm_medium=comment&amp;utm_campaign=pipeline-dotnet&amp;utm_content=fiftyone.pipeline.engines-messages.resx&amp;utm_term=missingpropertymessageproductnotincloudresource</value>
   </data>
   <data name="MissingPropertyMessagePropertyExcluded" xml:space="preserve">
     <value>This is because the property has been excluded when configuring the engine.</value>
   </data>
   <data name="MissingPropertyMessagePropertyNotInCloudResource" xml:space="preserve">
-    <value>This is because your resource key does not include access to this property. Properties that are included for this key under '{0}' are {1}. For more details on resource keys, see our explainer: https://51degrees.com/documentation/_info__resource_keys.html</value>
+    <value>This is because your resource key does not include access to this property. Properties that are included for this key under '{0}' are {1}. For more details on resource keys, see our explainer: https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&amp;utm_medium=comment&amp;utm_campaign=pipeline-dotnet&amp;utm_content=fiftyone.pipeline.engines-messages.resx&amp;utm_term=missingpropertymessagepropertynotincloudresource</value>
   </data>
   <data name="MissingPropertyMessageUnknown" xml:space="preserve">
     <value>The reason for this is unknown. Please check that the aspect and property name are correct.</value>

--- a/FiftyOne.Pipeline.Examples.Shared/FiftyOne.Pipeline.Examples.Shared.csproj
+++ b/FiftyOne.Pipeline.Examples.Shared/FiftyOne.Pipeline.Examples.Shared.csproj
@@ -14,7 +14,7 @@
 	<Copyright>51Degrees Mobile Experts Limited</Copyright>
 	<PackageTags>51degrees,pipeline,data service</PackageTags>
 	<RepositoryUrl>https://github.com/51Degrees/pipeline-dotnet</RepositoryUrl>
-	<PackageProjectUrl>https://51degrees.com</PackageProjectUrl>
+	<PackageProjectUrl>https://51degrees.com?utm_source=nuget&amp;utm_medium=package&amp;utm_campaign=pipeline-dotnet&amp;utm_content=fiftyone.pipeline.examples.shared-fiftyone.pipeline.examples.shared.csproj&amp;utm_term=packageprojecturl</PackageProjectUrl>
 	<Description>The 51Degrees Pipeline API provides a fast, modern architecture for consuming real-time digital data services. This package contains helper classes to make writing examples easier.</Description>
 	<PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/FiftyOne.Pipeline.Web.Shared/FiftyOne.Pipeline.Web.Shared.csproj
+++ b/FiftyOne.Pipeline.Web.Shared/FiftyOne.Pipeline.Web.Shared.csproj
@@ -14,7 +14,7 @@
     <Authors>51Degrees Engineering</Authors>
     <Copyright>51Degrees Mobile Experts Limited</Copyright>
     <PackageLicenseExpression>EUPL-1.2</PackageLicenseExpression>
-    <PackageProjectUrl>https://51degrees.com</PackageProjectUrl>
+    <PackageProjectUrl>https://51degrees.com?utm_source=nuget&amp;utm_medium=package&amp;utm_campaign=pipeline-dotnet&amp;utm_content=fiftyone.pipeline.web.shared-fiftyone.pipeline.web.shared.csproj&amp;utm_term=packageprojecturl</PackageProjectUrl>
     <PackageIcon>51d-logo.png</PackageIcon>
     <PackageIconUrl>https://51degrees.com/portals/0/Logos/Square%20Logo.png?width=64</PackageIconUrl>
     <RepositoryUrl>https://github.com/51Degrees/pipeline-dotnet</RepositoryUrl>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![51Degrees](https://raw.githubusercontent.com/51Degrees/common-ci/main/images/logo/360x67.png "Data rewards the curious") **Pipeline API**
 
-[Developer Documentation](https://51degrees.com/pipeline-dotnet/index.html?utm_source=github&utm_medium=repository&utm_content=documentation&utm_campaign=dotnet-open-source "developer documentation")
+[Developer Documentation](https://51degrees.com/pipeline-dotnet/index.html?utm_source=github&utm_medium=readme&utm_campaign=pipeline-dotnet&utm_content=readme.md&utm_term=top "developer documentation")
 | NuGet | Package | NuGet | Package |
 | --- | --- | --- | --- |
 | [![NuGet](https://img.shields.io/nuget/v/FiftyOne.Pipeline.CloudRequestEngine.svg)](https://www.nuget.org/packages/FiftyOne.Pipeline.CloudRequestEngine) | CloudRequestEngine | [![NuGet](https://img.shields.io/nuget/v/FiftyOne.Pipeline.Examples.Shared.svg)](https://www.nuget.org/packages/FiftyOne.Pipeline.Examples.Shared) | Examples.Shared |
@@ -30,7 +30,7 @@ The Web integration multi-targets the following:
     - .NET Core 8.0
     - .NET Framework 4.6.2
 
-The [tested versions](https://51degrees.com/documentation/_info__tested_versions.html) page shows the .NET versions that we currently test against. The software may run fine against other versions, but additional caution should be applied.
+The [tested versions](https://51degrees.com/documentation/_info__tested_versions.html?utm_source=github&utm_medium=readme&utm_campaign=pipeline-dotnet&utm_content=readme.md&utm_term=dependencies) page shows the .NET versions that we currently test against. The software may run fine against other versions, but additional caution should be applied.
 
 ## Strong naming
 
@@ -91,7 +91,7 @@ For example, Installing `FiftyOne.Pipeline.Engines.FiftyOne` will automatically 
 ### Pipeline Examples
 
 There are several examples available that demonstrate how to make use of the Pipeline API in isolation. These are described in the table below.
-If you want examples that demonstrate how to use 51Degrees products such as device detection, then these are available in the corresponding [repository](https://github.com/51Degrees/device-detection-dotnet) and on our [website](https://51degrees.com/documentation/_examples__device_detection__index.html).
+If you want examples that demonstrate how to use 51Degrees products such as device detection, then these are available in the corresponding [repository](https://github.com/51Degrees/device-detection-dotnet) and on our [website](https://51degrees.com/documentation/_examples__device_detection__index.html?utm_source=github&utm_medium=readme&utm_campaign=pipeline-dotnet&utm_content=readme.md&utm_term=pipeline-examples).
 
 | Example                                   | Description |
 |-------------------------------------------|-------------|
@@ -102,7 +102,7 @@ If you want examples that demonstrate how to use 51Degrees products such as devi
 | ResultCaching                             | Shows how the result caching feature works. |
 | UsageSharing                              | Shows how to share usage with 51Degrees. This helps us to keep our products up to date and accurate. |
 
-The CloudRequestEngine\GettingStarted example requires a resource key. It reads the aligned `51DEGREES_RESOURCE_KEY` environment variable first, then the legacy `RESOURCE_KEY` variable. A resource key with the free properties used by the examples can be created at https://configure.51degrees.com/Wkqxf3Bs.
+The CloudRequestEngine\GettingStarted example requires a resource key. It reads the aligned `51DEGREES_RESOURCE_KEY` environment variable first, then the legacy `RESOURCE_KEY` variable. A resource key with the free properties used by the examples can be created at https://configure.51degrees.com/Wkqxf3Bs?utm_source=github&utm_medium=readme&utm_campaign=pipeline-dotnet&utm_content=readme.md&utm_term=pipeline-examples.
 
 ## Tests
 
@@ -119,5 +119,5 @@ The tests can be run from within Visual Studio or (in most cases) by using the `
 
 For complete documentation on the Pipeline API and associated engines, see the [51Degrees documentation site][Documentation].
 
-[Documentation]: https://51degrees.com/documentation/index.html
+[Documentation]: https://51degrees.com/documentation/index.html?utm_source=github&utm_medium=readme&utm_campaign=pipeline-dotnet&utm_content=readme.md&utm_term=project-documentation
 [nuget]: https://www.nuget.org/profiles/51Degrees

--- a/Tests/FiftyOne.Pipeline.CloudRequestEngine.Tests/CloudAspectEngineBaseTests.cs
+++ b/Tests/FiftyOne.Pipeline.CloudRequestEngine.Tests/CloudAspectEngineBaseTests.cs
@@ -54,7 +54,7 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.Tests
             "Failed to load aspect properties for element '{0}'. This is " +
             "because your resource key does not include access to any " +
             "properties under '{0}'. For more details on resource keys, " +
-            "see our explainer: https://51degrees.com/documentation/_info__resource_keys.html";
+            "see our explainer: https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=comment&utm_campaign=pipeline-dotnet&utm_content=fiftyone.pipeline.cloudrequestengine-messages.resx&utm_term=exceptionfailedtoloadproperties";
 
         #region Test Classes
 

--- a/Web Integration/FiftyOne.Pipeline.Web/FiftyOne.Pipeline.Web.csproj
+++ b/Web Integration/FiftyOne.Pipeline.Web/FiftyOne.Pipeline.Web.csproj
@@ -8,7 +8,7 @@
     <DocumentationFile>FiftyOne.Pipeline.Web.xml</DocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
-    <PackageProjectUrl>https://51degrees.com</PackageProjectUrl>
+    <PackageProjectUrl>https://51degrees.com?utm_source=nuget&amp;utm_medium=package&amp;utm_campaign=pipeline-dotnet&amp;utm_content=web-integration-fiftyone.pipeline.web-fiftyone.pipeline.web.csproj&amp;utm_term=packageprojecturl</PackageProjectUrl>
     <Description>The 51Degrees Pipeline API provides a fast, modern architecture for consuming real-time digital data services. This package contains components that integrate the 51Degrees Pipeline API into ASP.NET and ASP.NET Core web projects.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>


### PR DESCRIPTION
## Summary

Every navigational 51degrees.com and configure.51degrees.com link in this repository now carries the standard UTM query string so the Content Team can trace Matomo campaign traffic to the exact repository, file, and location it came from:

`?utm_source=<github|code|nuget|npm|maven|packagist>&utm_medium=<readme|docs|example|comment|package>&utm_campaign=<repository>&utm_content=<file slug>&utm_term=<location in file>`

37 links across 30 files, in-place URL replacements only, including the links in the new FiftyOne.Did package family that landed on main this week. While tagging, http variants were normalised to https, pre-2026 utm schemes were replaced, and functional endpoints (cloud, distributor, devices-v4), test fixtures, license headers, and generated files are untouched.

## Lint

A second commit adds the utm-link-lint workflow, which runs the shared script from 51Degrees/common-ci on pull requests and pushes to main, keeping the convention enforced from now on. The lint check on this PR stays red until 51Degrees/common-ci#207 merges, since the workflow fetches the script from that repository's main.

The full convention is documented in UTM-LINK-TAGGING.md in 51Degrees/internal-common-ci (PR 3).