### PR TITLE
DOC: clarify 51Did envelope vs value terminology in FiftyOne.Did

### DIFF
--- a/FiftyOne.Did/FiftyOne.Did.csproj
+++ b/FiftyOne.Did/FiftyOne.Did.csproj
@@ -13,8 +13,8 @@
 
     <!-- NuGet package properties -->
     <PackageId>FiftyOne.Did</PackageId>
-    <Title>51Degrees Device Identifier (51Did) parser</Title>
-    <PackageDescription>Parses the 51Degrees device identifier (51Did) returned by the 51Degrees Cloud service. The 51Did is an OWID envelope (the identifier) whose payload carries a 1-byte flags bit-mask (usage tier and identifier type), a 4-byte little-endian License Id, and the identifier value: a 32-byte SHA-256 for probabilistic and hashed-email identifiers or 16 GUID bytes for random ones. Compare probabilistic values, never full identifiers: two 51Dids for the same device share the same value even though their envelopes differ on every issue. The FodId type inherits from Owid.Client.Model.Owid (SWAN-community/owid-dotnet) and unpacks those three payload fields.</PackageDescription>
+    <Title>51Degrees Identifier (51Did) parser</Title>
+    <PackageDescription>Parses the 51Degrees Identifier (51Did) returned by the 51Degrees Cloud service. A 51Did is carried in an envelope (a signed OWID) whose payload holds a 1-byte flags bit-mask (usage tier and identifier type), a 4-byte little-endian License Id, and the value. The value is a 32-byte SHA-256 for probabilistic and hashed-email identifiers, or 16 GUID bytes for random ones, and it is the stable part you compare. Two 51Dids for the same inputs share the same value even though their envelopes differ on every issue. The FodId type inherits from Owid.Client.Model.Owid (SWAN-community/owid-dotnet) and unpacks those payload fields. Compare values, never envelopes.</PackageDescription>
     <Authors>51Degrees Engineering</Authors>
     <PackageLicenseExpression>EUPL-1.2</PackageLicenseExpression>
     <PackageIconUrl>https://51degrees.com/portals/0/Logos/Square%20Logo.png?width=64</PackageIconUrl>
@@ -23,7 +23,7 @@
     <RepositoryUrl>https://github.com/51Degrees/pipeline-dotnet</RepositoryUrl>
     <PackageIcon>51d-logo.png</PackageIcon>
     <PackageProjectUrl>https://51degrees.com?utm_source=nuget&amp;utm_medium=package&amp;utm_campaign=pipeline-dotnet&amp;utm_content=fiftyone.did-fiftyone.did.csproj&amp;utm_term=packageprojecturl</PackageProjectUrl>
-    <Description>Parses the 51Degrees device identifier (51Did) returned by the 51Degrees Cloud service.</Description>
+    <Description>Parses the 51Degrees Identifier (51Did) returned by the 51Degrees Cloud service.</Description>
     <RepositoryType>git</RepositoryType>
     <NeutralLanguage>en</NeutralLanguage>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/FiftyOne.Did/FiftyOne.Did.xml
+++ b/FiftyOne.Did/FiftyOne.Did.xml
@@ -12,13 +12,16 @@
             </summary>
             <remarks>
             <para>
-            Terminology. The 51Did itself (this OWID envelope) is the
-            identifier. The 32-byte SHA-256 hash inside the payload is the
-            probabilistic value carried by that identifier; two responses for
-            the same device + IP + usage share the same probabilistic value
-            but differ at the byte level because the envelope embeds a fresh
-            date and signature on each call. Compare probabilistic values,
-            never full identifiers.
+            Terminology. A 51Did is described at three levels. The 51Did is
+            the identifier as a whole, meaning the concept and its rules. The
+            envelope is the data model that carries it, this OWID, holding the
+            version, domain, date, payload and signature, re-issued fresh on
+            every call. The value is the part of the envelope that is stable
+            and comparable, the payload bytes after Flags and LicenseId,
+            exposed as <see cref="P:FiftyOne.Did.Model.FodId.Hash"/>. Two responses for the same inputs
+            share the same value but differ at the byte level because the
+            envelope embeds a fresh date and signature on each call. Compare
+            values, never envelopes.
             </para>
             <para>
             Payload layout. The header (offsets 0-4) is shared by every
@@ -110,15 +113,14 @@
         </member>
         <member name="P:FiftyOne.Did.Model.FodId.Hash">
             <summary>
-            The value bytes from the payload: a 32-byte SHA-256 for
-            Probabilistic and HashedEmail identifiers, 16 GUID bytes for
-            Random ones.
-            This is the stable field for comparing two 51Did identifiers:
-            two identifiers for the same device + IP + usage share the
-            same probabilistic value even though their wrapping envelopes
-            (date, signature) differ on every issue. Treat as the cache /
-            dedup key. SHA-256 is the underlying hash function; the
-            property is named Hash to reflect that implementation detail.
+            The value bytes from the payload, a 32-byte SHA-256 for
+            Probabilistic and HashedEmail identifiers, or 16 GUID bytes for
+            Random ones. This is the stable, comparable part of the
+            envelope. Two 51Dids for the same inputs share the same value
+            even though their envelopes (date, signature) differ on every
+            issue. Treat it as the cache / dedup key. SHA-256 is the
+            underlying hash function for the probabilistic and hashed-email
+            types, and the property is named Hash to reflect that.
             </summary>
         </member>
         <member name="M:FiftyOne.Did.Model.FodId.#ctor(System.String)">
@@ -172,8 +174,8 @@
         </member>
         <member name="T:FiftyOne.Did.Model.FodIdExtensions">
             <summary>
-            Extension methods for resolving a 51Did value into a <see cref="T:FiftyOne.Did.Model.FodId"/>
-            in a single call.
+            Extension methods for resolving a base64-encoded 51Did into a
+            <see cref="T:FiftyOne.Did.Model.FodId"/> in a single call.
             </summary>
             <remarks>
             The 51Did cloud engine surfaces each identifier as a raw base64 string.

--- a/FiftyOne.Did/Model/FodId.cs
+++ b/FiftyOne.Did/Model/FodId.cs
@@ -31,13 +31,16 @@ namespace FiftyOne.Did.Model
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Terminology. The 51Did itself (this OWID envelope) is the
-    /// identifier. The 32-byte SHA-256 hash inside the payload is the
-    /// probabilistic value carried by that identifier; two responses for
-    /// the same device + IP + usage share the same probabilistic value
-    /// but differ at the byte level because the envelope embeds a fresh
-    /// date and signature on each call. Compare probabilistic values,
-    /// never full identifiers.
+    /// Terminology. A 51Did is described at three levels. The 51Did is
+    /// the identifier as a whole, meaning the concept and its rules. The
+    /// envelope is the data model that carries it, this OWID, holding the
+    /// version, domain, date, payload and signature, re-issued fresh on
+    /// every call. The value is the part of the envelope that is stable
+    /// and comparable, the payload bytes after Flags and LicenseId,
+    /// exposed as <see cref="Hash"/>. Two responses for the same inputs
+    /// share the same value but differ at the byte level because the
+    /// envelope embeds a fresh date and signature on each call. Compare
+    /// values, never envelopes.
     /// </para>
     /// <para>
     /// Payload layout. The header (offsets 0-4) is shared by every
@@ -129,15 +132,14 @@ namespace FiftyOne.Did.Model
         public uint LicenseId { get; private set; }
 
         /// <summary>
-        /// The value bytes from the payload: a 32-byte SHA-256 for
-        /// Probabilistic and HashedEmail identifiers, 16 GUID bytes for
-        /// Random ones.
-        /// This is the stable field for comparing two 51Did identifiers:
-        /// two identifiers for the same device + IP + usage share the
-        /// same probabilistic value even though their wrapping envelopes
-        /// (date, signature) differ on every issue. Treat as the cache /
-        /// dedup key. SHA-256 is the underlying hash function; the
-        /// property is named Hash to reflect that implementation detail.
+        /// The value bytes from the payload, a 32-byte SHA-256 for
+        /// Probabilistic and HashedEmail identifiers, or 16 GUID bytes for
+        /// Random ones. This is the stable, comparable part of the
+        /// envelope. Two 51Dids for the same inputs share the same value
+        /// even though their envelopes (date, signature) differ on every
+        /// issue. Treat it as the cache / dedup key. SHA-256 is the
+        /// underlying hash function for the probabilistic and hashed-email
+        /// types, and the property is named Hash to reflect that.
         /// </summary>
         public byte[] Hash { get; private set; } = Array.Empty<byte>();
 

--- a/FiftyOne.Did/Model/FodIdExtensions.cs
+++ b/FiftyOne.Did/Model/FodIdExtensions.cs
@@ -25,8 +25,8 @@ using System;
 namespace FiftyOne.Did.Model
 {
     /// <summary>
-    /// Extension methods for resolving a 51Did value into a <see cref="FodId"/>
-    /// in a single call.
+    /// Extension methods for resolving a base64-encoded 51Did into a
+    /// <see cref="FodId"/> in a single call.
     /// </summary>
     /// <remarks>
     /// The 51Did cloud engine surfaces each identifier as a raw base64 string.

--- a/FiftyOne.Did/README.md
+++ b/FiftyOne.Did/README.md
@@ -111,4 +111,4 @@ Key (for `idproblic`) or across all callers (for `idprobglobal`).
   with signature verification and a "Live 51d.es v3" sample.
 - The [51Did comparer](https://51degrees.com/developers/51did-comparer?utm_source=github&utm_medium=readme&utm_campaign=pipeline-dotnet&utm_content=fiftyone.did-readme.md&utm_term=see-also)
   for a side-by-side, byte-by-byte comparison of two 51Dids that
-  highlights the wrapper-vs-value distinction in action.
+  highlights the envelope-vs-value distinction in action.

--- a/FiftyOne.Did/README.md
+++ b/FiftyOne.Did/README.md
@@ -1,27 +1,29 @@
 # FiftyOne.Did
 
-Strongly-typed .NET parser for the 51Did (51Degrees device identifier)
+Strongly-typed .NET parser for the 51Did (51Degrees Identifier)
 returned by the 51Degrees Cloud service.
 
 ## Terminology
 
-The 51Did has two layers. The wording below treats them as distinct.
+A 51Did is described at three levels, and the wording below is used
+deliberately.
 
-- The **51Did** is the **identifier**. The whole base64 OWID envelope
-  (version, domain, date, payload, signature). It changes byte-for-byte
-  every time the cloud issues one, even for the same inputs, because
-  the date and signature change with each call.
-- The **probabilistic value** is one of the fields *inside* the payload
-  (a 32-byte SHA-256 hash). It is stable across reissues for the same
-  device + IP + usage: if two 51Dids were issued for the same inputs,
-  their probabilistic values are equal even though the wrapping
-  identifiers differ.
+- The **51Did** (51Degrees Identifier) is the identifier as a whole,
+  meaning the concept together with the rules for how it is issued,
+  compared and licensed. "A 51Did" means the identifier in this complete
+  sense, not any single field.
+- The **envelope** (also called the **wrapper**) is the data model that
+  carries a 51Did. It is a signed OWID holding the version, domain, date,
+  payload and signature, and it changes byte-for-byte every time the cloud
+  issues one, even for the same inputs, because the date and signature
+  change with each call.
+- The **value** is the part of the envelope that is stable and comparable.
+  It is the payload bytes after Flags and LicenseId, a 32-byte SHA-256 for
+  Probabilistic and HashedEmail identifiers, or a 16-byte GUID for Random.
+  Two 51Dids for the same inputs share the same value even though their
+  envelopes differ.
 
-Comparing two browsers means comparing the probabilistic values
-carried inside their identifiers, never the identifiers themselves.
-Calling either layer "the identifier" without qualification leads to
-incorrect comparisons; calling the inner field "the probabilistic
-identifier" is the same conflation in a different costume.
+Comparing two 51Dids means comparing their values, never their envelopes.
 
 ## Payload layout
 
@@ -78,13 +80,13 @@ string   roundTrip = fodId.AsBase64();
 var a = new FodId(idprobglobalA);
 var b = new FodId(idprobglobalB);
 
-// Wrapper bytes (Domain, Date, Signature) ARE different; the
-// identifier itself is not stable across reissues:
+// Envelope bytes (Domain, Date, Signature) ARE different. The
+// envelope is not stable across reissues:
 bool sameDate = a.Date == b.Date;                           // false
 bool sameSig  = a.Signature.SequenceEqual(b.Signature);     // false
 
-// The probabilistic value inside the payload IS stable; this is
-// what you actually compare:
+// The value inside the payload IS stable. This is what you
+// actually compare:
 bool sameValue = a.Hash.SequenceEqual(b.Hash);              // true
 ```
 


### PR DESCRIPTION
Part of a coordinated pass making the 51Did documentation consistent about three distinct concepts. Sibling PRs: documentation #202, cloud #163, Website #812, plus the rust `fodid` crate.

## What changed

`FiftyOne.Did` (README, `FodId`/`FodIdExtensions` doc comments, regenerated `FiftyOne.Did.xml`, and the NuGet Title/Description) reworded so the three levels are distinct:

- **51Did** (51Degrees Identifier): the identifier as a whole, the concept plus its rules.
- **Envelope** (the OWID, also called the wrapper): the data model that carries a 51Did. Re-issued fresh on every call, so its bytes change every time.
- **Value**: the stable, comparable part of the envelope (the payload bytes after Flags and LicenseId). Compare values, never envelopes.

## Why

The previous wording said "the 51Did **is** the identifier, the whole OWID envelope" and called the inner field the "**probabilistic value**". Both are wrong: the envelope is the data model *for* the 51Did, not the 51Did itself, and "probabilistic" is incorrect for the Random (GUID) and Hashed Email types. The NuGet metadata also called it a "device identifier", which is no longer accurate.

## Scope

Prose and doc comments only. No public API symbol renamed (`FodId`, `Hash`, `idprobglobal` unchanged). The `.xml` was regenerated by building the project (0 warnings, 0 errors).