### PR TITLE
harden flaky Selenium JS builder template tests

### DIFF
--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/JavaScriptBuilderElementTemplateTests.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/JavaScriptBuilderElementTemplateTests.cs
@@ -134,12 +134,7 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
             capturedPostData = null;
             IJavaScriptExecutor js = Driver;
             var q = js.ExecuteScript(BuildXHRJS($"{ClientServerUrl}51dpipeline/json"));
-            while (capturedPostData == null)
-            {
-                DumpNewLogs();
-                Thread.Sleep(1000);
-            }
-            DumpNewLogs();
+            WaitUntil(() => capturedPostData != null, "POST data from intercepted XHR");
             Assert.IsNotNull(capturedPostData);
         }
 
@@ -240,34 +235,22 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
             capturedCompleted = false;
             Action<string> WaitAndValidatePostData = (expectedData) =>
             {
-                while (capturedPostData == null)
-                {
-                    DumpNewLogs();
-                    Thread.Sleep(1000);
-                }
+                WaitUntil(() => capturedPostData != null, $"POST data containing [{expectedData}]");
                 Assert.IsTrue(capturedPostData.Contains(expectedData), $"[{capturedPostData}] does not contain [{expectedData}]");
             };
             Action WaitAndValidateScriptCompletion = () => {
-                while (!capturedCompleted)
-                {
-                    DumpNewLogs();
-                    Thread.Sleep(1000);
-                }
+                WaitUntil(() => capturedCompleted, "script completion callback");
             };
             IJavaScriptExecutor js = Driver;
             Action<string> WaitAndValidateSnippetCalled = (testCode) =>
             {
-                while (true)
+                object lastResult = null;
+                WaitUntil(() =>
                 {
-                    var objResult = js.ExecuteScript(testCode);
-                    if (objResult is bool newResult)
-                    {
-                        Assert.IsTrue(newResult);
-                        break;
-                    }
-                    DumpNewLogs();
-                    Thread.Sleep(1000);
-                };
+                    lastResult = js.ExecuteScript(testCode);
+                    return lastResult is bool;
+                }, $"snippet flag from [{testCode}]");
+                Assert.IsTrue((bool)lastResult);
             };
 
             string additionalCode
@@ -340,6 +323,30 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
             {
                 Assert.Fail($"Detected cookies after script completion: {cookieCount}");
             }
+        }
+
+        private static readonly TimeSpan WaitTimeout = TimeSpan.FromSeconds(60);
+
+        /// <summary>
+        /// Polls <paramref name="condition"/> until it returns true or
+        /// <see cref="WaitTimeout"/> elapses, failing the test on timeout.
+        /// Replaces the previous unbounded spin loops: those would hang until the
+        /// runner's hang-dump aborted the thread mid-WebDriver-command, crashing
+        /// the shared Chrome tab and poisoning every later test in the class.
+        /// </summary>
+        private void WaitUntil(Func<bool> condition, string description)
+        {
+            var deadline = DateTime.UtcNow + WaitTimeout;
+            while (!condition())
+            {
+                DumpNewLogs();
+                if (DateTime.UtcNow >= deadline)
+                {
+                    Assert.Fail($"Timed out after {WaitTimeout.TotalSeconds:0}s waiting for {description}.");
+                }
+                Thread.Sleep(1000);
+            }
+            DumpNewLogs();
         }
 
         private void DumpNewLogs()

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/JavaScriptBuilderElementTestsBase.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/JavaScriptBuilderElementTestsBase.cs
@@ -47,6 +47,12 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
 
         public static Task ClassInit(TestContext context)
         {
+            CreateDriver();
+            return Task.CompletedTask;
+        }
+
+        private static void CreateDriver()
+        {
             var chromeOptions = new ChromeOptions();
             chromeOptions.SetLoggingPreference(LogType.Browser, OpenQA.Selenium.LogLevel.Info);
             chromeOptions.AcceptInsecureCertificates = true;
@@ -61,17 +67,44 @@ namespace FiftyOne.Pipeline.JavaScript.Tests
             try
             {
                 Driver = new ChromeDriver(chromeOptions);
+                // Bound a stuck navigation so GoToUrl throws quickly instead of
+                // blocking until the runner's hang-dump aborts the thread and
+                // crashes the tab.
+                Driver.Manage().Timeouts().PageLoad = TimeSpan.FromSeconds(60);
             }
             catch (WebDriverException)
             {
                 Assert.Inconclusive("Could not create a ChromeDriver, check " +
                                     "that the Chromium driver is installed");
             }
-
-            return Task.CompletedTask;
         }
-        
+
+        /// <summary>
+        /// The <see cref="Driver"/> is shared across the whole class, so a test
+        /// that leaves Chrome in a crashed state ("tab crashed") would otherwise
+        /// cascade into a failure for every remaining test. Probe the session and
+        /// recreate the driver if it has died.
+        /// </summary>
+        private static void EnsureDriverAlive()
+        {
+            try
+            {
+                _ = Driver?.CurrentWindowHandle;
+            }
+            catch (WebDriverException)
+            {
+                try { Driver?.Quit(); } catch (WebDriverException) { /* already gone */ }
+                Driver = null;
+            }
+
+            if (Driver == null)
+            {
+                CreateDriver();
+            }
+        }
+
         public virtual Task Init() {
+            EnsureDriverAlive();
             ClientServerUrl = $"http://localhost:{TestHttpListener.GetRandomUnusedPort()}/";
             
             _mockjsonBuilderElement = new Mock<IJsonBuilderElement>();


### PR DESCRIPTION
The `JavaScriptBuilderTemplate` Selenium tests intermittently hung for minutes on a single case, tripping the CI hang-dump which crashed the shared Chrome tab and cascaded into failures for every remaining test in the class. Waits now fail fast and a crashed driver is rebuilt.

## Changes
- Replace the unbounded poll loops in with a 60s-bounded `WaitUntil` that fails with a clear message instead of spinning until the runner aborts the thread mid-command.
- Add per-test driver liveness check + recreate, plus a 60s page-load timeout, so one crashed tab no longer poisons the rest of the class.