### PR TITLE
Align env var names with the DD repo

### DIFF
--- a/.github/workflows/cloud-51did.yml
+++ b/.github/workflows/cloud-51did.yml
@@ -3,7 +3,7 @@ name: Cloud 51Did Tests
 # Runs the live cloud 51Did integration test (Tests/FiftyOne.Did.Tests,
 # CloudFodIdTests) once for every resource key the central common-ci script
 # exports from the _51DEGREES_RESOURCE_KEY* secrets (free, paid and any added
-# later). Each run sets the single 51DEGREES_RESOURCE_KEY the test reads. New
+# later). Each run sets the single _51DEGREES_RESOURCE_KEY the test reads. New
 # resource keys are added once at the organisation level; this workflow needs
 # no change.
 
@@ -55,7 +55,7 @@ jobs:
           $failed = $false
           foreach ($k in $keys) {
             Write-Host "::group::CloudFodIdTests with $($k.Name)"
-            ${env:51DEGREES_RESOURCE_KEY} = $k.Value
+            $env:_51DEGREES_RESOURCE_KEY = $k.Value
             dotnet test $project -c Release --no-build --nologo `
               --filter 'FullyQualifiedName~CloudFodIdTests' `
               --logger 'console;verbosity=normal'

--- a/Examples/CloudRequestEngine/GettingStarted/Program.cs
+++ b/Examples/CloudRequestEngine/GettingStarted/Program.cs
@@ -45,18 +45,18 @@ namespace GettingStarted
                 .SetEndPoint("https://cloud.51degrees.com/api/v4/json")
                 // A resource key with the properties needed by the examples
                 // can be created at https://configure.51degrees.com/Wkqxf3Bs?utm_source=code&utm_medium=example&utm_campaign=pipeline-dotnet&utm_content=examples-cloudrequestengine-gettingstarted-program.cs&utm_term=main.
-                // The aligned 51DEGREES_RESOURCE_KEY environment variable is
+                // The aligned _51DEGREES_RESOURCE_KEY environment variable is
                 // checked first, then the legacy RESOURCE_KEY variable.
                 .SetResourceKey(GetResourceKey())
                 .SetLazyLoading(cfg)
                 .Build();
-                
+
 
             using (var pipeline = new PipelineBuilder(_loggerFactory).AddFlowElement(engine).Build())
             {
                 var data = pipeline.CreateFlowData();
                 data.AddEvidence("query.User-Agent", "iPhone");
-                data.Process();                    
+                data.Process();
                 var result = data.GetFromElement(engine).JsonResponse;
                 Console.WriteLine(result);
             }
@@ -66,7 +66,7 @@ namespace GettingStarted
 
         /// <summary>
         /// Get the resource key to use for this example. The aligned
-        /// 51DEGREES_RESOURCE_KEY environment variable is checked first,
+        /// _51DEGREES_RESOURCE_KEY environment variable is checked first,
         /// then the legacy RESOURCE_KEY variable. If neither is set then
         /// the hard-coded key below is used, preserving the previous
         /// behaviour of this example.
@@ -74,7 +74,7 @@ namespace GettingStarted
         private static string GetResourceKey()
         {
             var resourceKey =
-                Environment.GetEnvironmentVariable("51DEGREES_RESOURCE_KEY");
+                Environment.GetEnvironmentVariable("_51DEGREES_RESOURCE_KEY");
             if (string.IsNullOrEmpty(resourceKey))
             {
                 resourceKey = Environment.GetEnvironmentVariable("RESOURCE_KEY");

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ the concepts and design of this API.
 ## Dependencies
 
 Visual Studio 2022 or later is recommended. Although Visual Studio Code can be used for working with most of the projects.
- 
+
 The Pipeline projects are written in C# and target .NET Standard 2.0.3
 The Web integration multi-targets the following:
     - .NET Core 3.1
@@ -55,7 +55,7 @@ Rather than wait, the Stubble source is vendored under [`vendor/Stubble/`](vendo
 
 - **FiftyOne.Pipeline** - The core projects that comprise the Pipeline API.
   - *FiftyOne.Pipeline.Core* - The core Pipeline classes such as Pipeline, FlowData, FlowElement and Evidence.
-  - *FiftyOne.Pipeline.Engines* - Functionality for AspectEngines, a specialized FlowElement with additional features. 
+  - *FiftyOne.Pipeline.Engines* - Functionality for AspectEngines, a specialized FlowElement with additional features.
   - *FiftyOne.Pipeline.Engines.FiftyOne* - Functionality that is specific to 51Degrees aspect engines.
 - **FiftyOne.Pipeline.Web** - Projects that are relevant to the Pipeline API ASP.NET integration.
   - *FiftyOne.Pipeline.Web* - ASP.NET Core integration.
@@ -102,7 +102,7 @@ If you want examples that demonstrate how to use 51Degrees products such as devi
 | ResultCaching                             | Shows how the result caching feature works. |
 | UsageSharing                              | Shows how to share usage with 51Degrees. This helps us to keep our products up to date and accurate. |
 
-The CloudRequestEngine\GettingStarted example requires a resource key. It reads the aligned `51DEGREES_RESOURCE_KEY` environment variable first, then the legacy `RESOURCE_KEY` variable. A resource key with the free properties used by the examples can be created at https://configure.51degrees.com/Wkqxf3Bs?utm_source=github&utm_medium=readme&utm_campaign=pipeline-dotnet&utm_content=readme.md&utm_term=pipeline-examples.
+The CloudRequestEngine\GettingStarted example requires a resource key. It reads the aligned `_51DEGREES_RESOURCE_KEY` environment variable first, then the legacy `RESOURCE_KEY` variable. A resource key with the free properties used by the examples can be created at https://configure.51degrees.com/Wkqxf3Bs?utm_source=github&utm_medium=readme&utm_campaign=pipeline-dotnet&utm_content=readme.md&utm_term=pipeline-examples.
 
 ## Tests
 
@@ -113,7 +113,7 @@ The CloudRequestEngine\GettingStarted example requires a resource key. It reads 
 - **FiftyOne.Pipeline.Examples.Tests** - Tests for developer examples. This will automatically run all the examples and ensure they do not crash.
 - **FiftyOne.Pipeline.Web.Tests** - Tests for web integration functionality.
 
-The tests can be run from within Visual Studio or (in most cases) by using the `dotnet test` command line tool. 
+The tests can be run from within Visual Studio or (in most cases) by using the `dotnet test` command line tool.
 
 ## Project documentation
 

--- a/Tests/FiftyOne.Did.Tests/CloudFodIdTests.cs
+++ b/Tests/FiftyOne.Did.Tests/CloudFodIdTests.cs
@@ -37,14 +37,14 @@ namespace FiftyOne.Did.Tests
     /// <remarks>
     /// <para>
     /// The test uses a single resource key from the environment. Set
-    /// <c>51DEGREES_RESOURCE_KEY</c> (or the legacy <c>SUPER_RESOURCE_KEY</c>)
+    /// <c>_51DEGREES_RESOURCE_KEY</c> (or the legacy <c>SUPER_RESOURCE_KEY</c>)
     /// to a key whose properties include <c>fodid.*</c>. With no key set the
     /// test is inconclusive.
     /// </para>
     /// <para>
     /// To exercise more than one key (for example a free key and a paid key),
     /// the CI workflow runs this test once per <c>_51DEGREES_RESOURCE_KEY*</c>
-    /// secret, setting <c>51DEGREES_RESOURCE_KEY</c> to each in turn. The test
+    /// secret, setting <c>_51DEGREES_RESOURCE_KEY</c> to each in turn. The test
     /// itself only ever reads the single variable.
     /// </para>
     /// <para>
@@ -68,7 +68,7 @@ namespace FiftyOne.Did.Tests
         /// The aligned environment variable name used to supply the resource
         /// key. Checked before the legacy name.
         /// </summary>
-        private const string ResourceKeyEnvVar = "51DEGREES_RESOURCE_KEY";
+        private const string ResourceKeyEnvVar = "_51DEGREES_RESOURCE_KEY";
 
         /// <summary>
         /// The legacy environment variable name, checked when


### PR DESCRIPTION
`device-detection-dotnet` switched to underscore-prefixed 51DEGREES variables to avoid issues with software that expects them to be valid identifier.