### PR TITLE
DOCS: Improve customer-facing error message wording

### DIFF
--- a/FiftyOne.Pipeline.CloudRequestEngine/Messages.resx
+++ b/FiftyOne.Pipeline.CloudRequestEngine/Messages.resx
@@ -136,7 +136,7 @@
     <value>The '{0}' did not process because the JSON response from the CloudRequestEngine was null or empty. This indicates that the cloud request failed.</value>
   </data>
   <data name="ExceptionFailedToLoadProperties" xml:space="preserve">
-    <value>Failed to load aspect properties for element '{0}'. This is because your resource key does not include access to any properties under '{0}'. For more details on resource keys, see our explainer: https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&amp;utm_medium=comment&amp;utm_campaign=pipeline-dotnet&amp;utm_content=fiftyone.pipeline.cloudrequestengine-messages.resx&amp;utm_term=exceptionfailedtoloadproperties</value>
+    <value>Failed to load properties for '{0}'. This usually means your resource key does not include access to any properties under '{0}'. Check or create a resource key with the properties you need in the configurator at https://configure.51degrees.com?utm_source=code&amp;utm_medium=comment&amp;utm_campaign=pipeline-dotnet&amp;utm_content=fiftyone.pipeline.cloudrequestengine-messages.resx&amp;utm_term=exceptionfailedtoloadproperties.</value>
   </data>
   <data name="ExceptionResourceKeyNeeded" xml:space="preserve">
     <value>A resource key is required to access the 51Degrees cloud service. Please use the 'SetResourceKey' method to supply your resource key. You can obtain one for free from https://configure.51degrees.com?utm_source=code&amp;utm_medium=comment&amp;utm_campaign=pipeline-dotnet&amp;utm_content=fiftyone.pipeline.cloudrequestengine-messages.resx&amp;utm_term=exceptionresourcekeyneeded</value>

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JsonBuilderElement/Messages.resx
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JsonBuilderElement/Messages.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ExceptionSequenceNumberNotPresent" xml:space="preserve">
-    <value>The value for the ‘sequence’ parameter could not found. See https://51degrees.com/documentation/_info__error_messages.html?utm_source=code&amp;utm_medium=comment&amp;utm_campaign=pipeline-dotnet&amp;utm_content=fiftyone.pipeline.elements-fiftyone.pipeline.jsonbuilderelement-messages.resx&amp;utm_term=exceptionsequencenumbernotpresent#Sequence_value_not_found for more information.</value>
+    <value>The value for the 'sequence' parameter could not be found. See https://51degrees.com/documentation/4.5/_services__cloud__error_messages.html?utm_source=code&amp;utm_medium=comment&amp;utm_campaign=pipeline-dotnet&amp;utm_content=fiftyone.pipeline.elements-fiftyone.pipeline.jsonbuilderelement-messages.resx&amp;utm_term=exceptionsequencenumbernotpresent for more information.</value>
   </data>
 </root>

--- a/FiftyOne.Pipeline.Engines.FiftyOne/Messages.resx
+++ b/FiftyOne.Pipeline.Engines.FiftyOne/Messages.resx
@@ -133,7 +133,7 @@
     <value>Failed to increment usage sequence number</value>
   </data>
   <data name="MessageFailSequenceNumberParse" xml:space="preserve">
-    <value>The value for the ‘sequence’ parameter is not valid. See https://51degrees.com/documentation/_info__error_messages.html?utm_source=code&amp;utm_medium=comment&amp;utm_campaign=pipeline-dotnet&amp;utm_content=fiftyone.pipeline.engines.fiftyone-messages.resx&amp;utm_term=messagefailsequencenumberparse#Sequence_value_invalid for more information.</value>
+    <value>The value for the 'sequence' parameter is not valid. See https://51degrees.com/documentation/4.5/_services__cloud__error_messages.html?utm_source=code&amp;utm_medium=comment&amp;utm_campaign=pipeline-dotnet&amp;utm_content=fiftyone.pipeline.engines.fiftyone-messages.resx&amp;utm_term=messagefailsequencenumberparse for more information.</value>
   </data>
   <data name="MessageFailSequenceNumberRetreive" xml:space="preserve">
     <value>Failed to retrieve sequence number</value>

--- a/FiftyOne.Pipeline.Engines/Messages.resx
+++ b/FiftyOne.Pipeline.Engines/Messages.resx
@@ -172,7 +172,7 @@
     <value>An unhandled error occurred while checking for automatic updates for engine '{0}'</value>
   </data>
   <data name="MissingPropertyMessageDataUpgradeRequired" xml:space="preserve">
-    <value>This is because your license and/or data file does not include this property. The property is available with the {0} license/data for the {1}</value>
+    <value>This is because your license or data file does not include this property. It is available with the {0} license/data for the {1}. To upgrade, see https://51degrees.com/pricing?utm_source=code&amp;utm_medium=comment&amp;utm_campaign=pipeline-dotnet&amp;utm_content=fiftyone.pipeline.engines-messages.resx&amp;utm_term=missingpropertymessagedataupgraderequired.</value>
   </data>
   <data name="MissingPropertyMessageCloudRequestFailed" xml:space="preserve">
     <value>This is because an upstream cloud request failed, so no data was available to populate the property.</value>
@@ -181,13 +181,13 @@
     <value>Property '{0}' not found in data for element '{1}'. </value>
   </data>
   <data name="MissingPropertyMessageProductNotInCloudResource" xml:space="preserve">
-    <value>This is because your resource key does not include access to any properties under '{0}'. For more details on resource keys, see our explainer: https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&amp;utm_medium=comment&amp;utm_campaign=pipeline-dotnet&amp;utm_content=fiftyone.pipeline.engines-messages.resx&amp;utm_term=missingpropertymessageproductnotincloudresource</value>
+    <value>This is because your resource key does not include access to any properties under '{0}'. Check or create a resource key with the properties you need in the configurator at https://configure.51degrees.com?utm_source=code&amp;utm_medium=comment&amp;utm_campaign=pipeline-dotnet&amp;utm_content=fiftyone.pipeline.engines-messages.resx&amp;utm_term=missingpropertymessageproductnotincloudresource.</value>
   </data>
   <data name="MissingPropertyMessagePropertyExcluded" xml:space="preserve">
     <value>This is because the property has been excluded when configuring the engine.</value>
   </data>
   <data name="MissingPropertyMessagePropertyNotInCloudResource" xml:space="preserve">
-    <value>This is because your resource key does not include access to this property. Properties that are included for this key under '{0}' are {1}. For more details on resource keys, see our explainer: https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&amp;utm_medium=comment&amp;utm_campaign=pipeline-dotnet&amp;utm_content=fiftyone.pipeline.engines-messages.resx&amp;utm_term=missingpropertymessagepropertynotincloudresource</value>
+    <value>This is because your resource key does not include access to this property. The properties included for your key under '{0}' are {1}. Check or change your key in the configurator at https://configure.51degrees.com?utm_source=code&amp;utm_medium=comment&amp;utm_campaign=pipeline-dotnet&amp;utm_content=fiftyone.pipeline.engines-messages.resx&amp;utm_term=missingpropertymessagepropertynotincloudresource.</value>
   </data>
   <data name="MissingPropertyMessageUnknown" xml:space="preserve">
     <value>The reason for this is unknown. Please check that the aspect and property name are correct.</value>

--- a/Tests/FiftyOne.Pipeline.CloudRequestEngine.Tests/CloudAspectEngineBaseTests.cs
+++ b/Tests/FiftyOne.Pipeline.CloudRequestEngine.Tests/CloudAspectEngineBaseTests.cs
@@ -50,11 +50,15 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.Tests
         /// Expected properties error, duplicated here as error Messages has 
         /// internal access modifier.
         /// </summary>
-        private static readonly string PropertiesError = 
-            "Failed to load aspect properties for element '{0}'. This is " +
-            "because your resource key does not include access to any " +
-            "properties under '{0}'. For more details on resource keys, " +
-            "see our explainer: https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=comment&utm_campaign=pipeline-dotnet&utm_content=fiftyone.pipeline.cloudrequestengine-messages.resx&utm_term=exceptionfailedtoloadproperties";
+        private static readonly string PropertiesError =
+            "Failed to load properties for '{0}'. This usually means your " +
+            "resource key does not include access to any properties under " +
+            "'{0}'. Check or create a resource key with the properties you " +
+            "need in the configurator at " +
+            "https://configure.51degrees.com?utm_source=code&utm_medium=comment" +
+            "&utm_campaign=pipeline-dotnet&utm_content=fiftyone.pipeline." +
+            "cloudrequestengine-messages.resx&utm_term=" +
+            "exceptionfailedtoloadproperties.";
 
         #region Test Classes
 


### PR DESCRIPTION
Apply the reviewed wording to six messages, matching the cloud message review, and keep the repo's UTM link convention.

ExceptionFailedToLoadProperties,
MissingPropertyMessageProductNotInCloudResource and MissingPropertyMessagePropertyNotInCloudResource now point at the configurator (create or change a resource key with the properties you need) instead of the resource-keys explainer.
MissingPropertyMessageDataUpgradeRequired adds an upgrade path to the pricing page. MessageFailSequenceNumberParse and
ExceptionSequenceNumberNotPresent use the live 4.5 cloud error-messages page, and the latter also fixes "could not found".

All 51degrees.com and configure.51degrees.com links keep the utm_source=code, utm_medium=comment, utm_campaign=pipeline-dotnet, per-file utm_content and per-key utm_term parameters so the UTM link lint passes. Value-only resx edits with no new keys, so the Designer is unchanged. Update the CloudAspectEngineBaseTests expected string.