### PR TITLE
Warm CloudRequestEngine discovery at Build()

### DIFF
--- a/FiftyOne.Pipeline.CloudRequestEngine/FlowElements/CloudRequestEngine.cs
+++ b/FiftyOne.Pipeline.CloudRequestEngine/FlowElements/CloudRequestEngine.cs
@@ -35,6 +35,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Net.Http;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using FiftyOne.Pipeline.Core.Exceptions;
@@ -287,11 +288,12 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.FlowElements
                          true)
                 };
 
-                // Start the tasks to get the evidence keys and the public
-                // properties from the cloud service. If the stop token is
-                // not provided then warn via logging.
+                // Set up lazy initialization for the evidence keys and the
+                // public properties. The values are fetched from the cloud
+                // service on first access, or during WarmUp when the engine
+                // is created through CloudRequestEngineBuilder.
 
-                _lazyEvidenceKeyFilter 
+                _lazyEvidenceKeyFilter
                     = new Lazy<IEvidenceKeyFilter>(
                         GetCloudEvidenceKeys,
                         LazyThreadSafetyMode.PublicationOnly);
@@ -423,6 +425,43 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.FlowElements
                     }
                     throw;
                 }
+            }
+        }
+
+        /// <summary>
+        /// Fetch <see cref="PublicProperties"/> and
+        /// <see cref="EvidenceKeyFilter"/> from the cloud service so that
+        /// the first call to Process does not have to pay the cost of
+        /// these requests.
+        /// The two requests are made in parallel and this method blocks
+        /// until both have completed.
+        /// <see cref="CloudRequestEngineBuilder.Build"/> calls this before
+        /// returning, so an engine created through the builder is ready
+        /// to serve as soon as it is returned.
+        /// </summary>
+        /// <exception cref="CloudRequestException">
+        /// Thrown if there is an error from the cloud service or
+        /// there is no data in the response.
+        /// </exception>
+        public void WarmUp()
+        {
+            var discoveryTasks = new[]
+            {
+                Task.Run(() => { var _ = PublicProperties; }),
+                Task.Run(() => { var _ = EvidenceKeyFilter; }),
+            };
+            try
+            {
+                Task.WaitAll(discoveryTasks);
+            }
+            catch (AggregateException ex)
+            {
+                // Surface the underlying failure directly so that callers
+                // get the same exception type that the PublicProperties and
+                // EvidenceKeyFilter getters would have thrown.
+                ExceptionDispatchInfo.Capture(
+                    ex.InnerExceptions[0]).Throw();
+                throw;
             }
         }
 

--- a/FiftyOne.Pipeline.CloudRequestEngine/FlowElements/CloudRequestEngine.cs
+++ b/FiftyOne.Pipeline.CloudRequestEngine/FlowElements/CloudRequestEngine.cs
@@ -442,9 +442,14 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.FlowElements
         /// response such as an invalid resource key) is thrown, as retrying
         /// would never succeed. A transient failure (the service being
         /// unreachable, a timeout or a 5xx response) is only logged as a
-        /// warning - the discovery requests will be retried on first use,
-        /// so a temporary cloud outage does not prevent the engine from
-        /// being constructed.
+        /// warning, so a temporary cloud outage does not prevent the engine
+        /// from being constructed - the discovery requests will be retried
+        /// on first use, subject to the configured
+        /// <see cref="IRecoveryStrategy"/>. Note that the failed warmup
+        /// attempts count towards the failures-to-enter-recovery threshold,
+        /// so with an aggressive threshold (1 or 2) the engine may throw
+        /// <see cref="CloudRequestEngineTemporarilyUnavailableException"/>
+        /// on use until the recovery period has passed.
         /// </summary>
         /// <exception cref="CloudRequestException">
         /// Thrown if the cloud service definitively rejected a discovery
@@ -467,7 +472,7 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.FlowElements
                 // Surface a definitive failure directly so that callers
                 // get the same exception type that the PublicProperties and
                 // EvidenceKeyFilter getters would have thrown.
-                var definitive = ex.InnerExceptions
+                var definitive = ex.Flatten().InnerExceptions
                     .FirstOrDefault(IsDefinitiveConfigurationError);
                 if (definitive != null)
                 {

--- a/FiftyOne.Pipeline.CloudRequestEngine/FlowElements/CloudRequestEngine.cs
+++ b/FiftyOne.Pipeline.CloudRequestEngine/FlowElements/CloudRequestEngine.cs
@@ -438,10 +438,18 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.FlowElements
         /// <see cref="CloudRequestEngineBuilder.Build"/> calls this before
         /// returning, so an engine created through the builder is ready
         /// to serve as soon as it is returned.
+        /// A definitive configuration error from the cloud service (a 4xx
+        /// response such as an invalid resource key) is thrown, as retrying
+        /// would never succeed. A transient failure (the service being
+        /// unreachable, a timeout or a 5xx response) is only logged as a
+        /// warning - the discovery requests will be retried on first use,
+        /// so a temporary cloud outage does not prevent the engine from
+        /// being constructed.
         /// </summary>
         /// <exception cref="CloudRequestException">
-        /// Thrown if there is an error from the cloud service or
-        /// there is no data in the response.
+        /// Thrown if the cloud service definitively rejected a discovery
+        /// request (4xx response), for example because the resource key
+        /// is invalid.
         /// </exception>
         public void WarmUp()
         {
@@ -456,13 +464,35 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.FlowElements
             }
             catch (AggregateException ex)
             {
-                // Surface the underlying failure directly so that callers
+                // Surface a definitive failure directly so that callers
                 // get the same exception type that the PublicProperties and
                 // EvidenceKeyFilter getters would have thrown.
-                ExceptionDispatchInfo.Capture(
-                    ex.InnerExceptions[0]).Throw();
-                throw;
+                var definitive = ex.InnerExceptions
+                    .FirstOrDefault(IsDefinitiveConfigurationError);
+                if (definitive != null)
+                {
+                    ExceptionDispatchInfo.Capture(definitive).Throw();
+                }
+                Logger?.LogWarning(ex,
+                    "Failed to warm up the cloud request engine due to a " +
+                    "transient error. The engine will retry the discovery " +
+                    "requests when it is first used.");
             }
+        }
+
+        /// <summary>
+        /// True if the exception indicates that the cloud service received
+        /// the discovery request and definitively rejected it (4xx), so
+        /// retrying with the same configuration can never succeed.
+        /// Network failures, timeouts and 5xx responses are not definitive -
+        /// they can resolve themselves, so the caller should fall back to
+        /// retrying lazily rather than failing.
+        /// </summary>
+        private static bool IsDefinitiveConfigurationError(Exception ex)
+        {
+            return ex is CloudRequestException cloudEx &&
+                cloudEx.HttpStatusCode >= 400 &&
+                cloudEx.HttpStatusCode < 500;
         }
 
         /// <summary>

--- a/FiftyOne.Pipeline.CloudRequestEngine/FlowElements/CloudRequestEngineBuilder.cs
+++ b/FiftyOne.Pipeline.CloudRequestEngine/FlowElements/CloudRequestEngineBuilder.cs
@@ -329,8 +329,20 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.FlowElements
         /// <summary>
         /// Build and return a new <see cref="CloudRequestEngine"/>
         /// instance using the current configuration.
+        /// The returned engine has already fetched the accessible
+        /// properties and evidence keys from the cloud service, so the
+        /// first call to Process does not pay the cost of these requests.
+        /// This means that this method requires the cloud service to be
+        /// reachable and will throw if it is not.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>
+        /// A new <see cref="CloudRequestEngine"/> that is ready to serve
+        /// requests.
+        /// </returns>
+        /// <exception cref="CloudRequestException">
+        /// Thrown if there is an error from the cloud service or
+        /// there is no data in the response.
+        /// </exception>
         public CloudRequestEngine Build()
         {
             if (string.IsNullOrWhiteSpace(_resourceKey))
@@ -357,7 +369,19 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.FlowElements
                 SetEvidenceKeysEndpoint(endpoint + Constants.EVIDENCE_KEYS_FILENAME);
             }
 
-            return BuildEngine();
+            var engine = BuildEngine();
+            try
+            {
+                engine.WarmUp();
+            }
+            catch
+            {
+                // A failed warmup means the engine must not be returned,
+                // so make sure it is not left registered anywhere.
+                engine.Dispose();
+                throw;
+            }
+            return engine;
         }
 
         private CloudRequestData CreateAspectData(IPipeline pipeline, 

--- a/FiftyOne.Pipeline.CloudRequestEngine/FlowElements/CloudRequestEngineBuilder.cs
+++ b/FiftyOne.Pipeline.CloudRequestEngine/FlowElements/CloudRequestEngineBuilder.cs
@@ -329,17 +329,12 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.FlowElements
         /// <summary>
         /// Build and return a new <see cref="CloudRequestEngine"/>
         /// instance using the current configuration.
-        /// This fetches the accessible properties and evidence keys from
-        /// the cloud service before returning, so the first call to
-        /// Process does not pay the cost of these requests.
-        /// If the cloud service definitively rejects a discovery request
-        /// (a 4xx response such as an invalid resource key) then this
-        /// method throws, as retrying with the same configuration can
-        /// never succeed. If the discovery requests fail transiently (the
-        /// service is unreachable, times out or returns a 5xx response)
-        /// then the engine is still returned and the discovery requests
-        /// are retried when the engine is first used, so a temporary cloud
-        /// outage does not prevent the application from starting.
+        /// This calls <see cref="CloudRequestEngine.WarmUp"/> before
+        /// returning, so the first call to Process does not pay the cost
+        /// of the discovery requests. See that method's documentation for
+        /// the failure semantics: a definitive configuration error (4xx)
+        /// throws, while a transient failure falls back to retrying on
+        /// first use.
         /// </summary>
         /// <returns>
         /// A new <see cref="CloudRequestEngine"/>.
@@ -383,8 +378,19 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.FlowElements
             catch
             {
                 // A failed warmup means the engine must not be returned,
-                // so make sure it is not left registered anywhere.
-                engine.Dispose();
+                // so make sure it is not left registered anywhere. A
+                // dispose failure is only logged so that it cannot mask
+                // the warmup exception.
+                try
+                {
+                    engine.Dispose();
+                }
+                catch (Exception disposeEx)
+                {
+                    _loggerFactory.CreateLogger<CloudRequestEngineBuilder>()
+                        .LogWarning(disposeEx,
+                            "Failed to dispose engine after warmup failure.");
+                }
                 throw;
             }
             return engine;

--- a/FiftyOne.Pipeline.CloudRequestEngine/FlowElements/CloudRequestEngineBuilder.cs
+++ b/FiftyOne.Pipeline.CloudRequestEngine/FlowElements/CloudRequestEngineBuilder.cs
@@ -329,19 +329,25 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.FlowElements
         /// <summary>
         /// Build and return a new <see cref="CloudRequestEngine"/>
         /// instance using the current configuration.
-        /// The returned engine has already fetched the accessible
-        /// properties and evidence keys from the cloud service, so the
-        /// first call to Process does not pay the cost of these requests.
-        /// This means that this method requires the cloud service to be
-        /// reachable and will throw if it is not.
+        /// This fetches the accessible properties and evidence keys from
+        /// the cloud service before returning, so the first call to
+        /// Process does not pay the cost of these requests.
+        /// If the cloud service definitively rejects a discovery request
+        /// (a 4xx response such as an invalid resource key) then this
+        /// method throws, as retrying with the same configuration can
+        /// never succeed. If the discovery requests fail transiently (the
+        /// service is unreachable, times out or returns a 5xx response)
+        /// then the engine is still returned and the discovery requests
+        /// are retried when the engine is first used, so a temporary cloud
+        /// outage does not prevent the application from starting.
         /// </summary>
         /// <returns>
-        /// A new <see cref="CloudRequestEngine"/> that is ready to serve
-        /// requests.
+        /// A new <see cref="CloudRequestEngine"/>.
         /// </returns>
         /// <exception cref="CloudRequestException">
-        /// Thrown if there is an error from the cloud service or
-        /// there is no data in the response.
+        /// Thrown if the cloud service definitively rejected a discovery
+        /// request (4xx response), for example because the resource key
+        /// is invalid.
         /// </exception>
         public CloudRequestEngine Build()
         {

--- a/Tests/FiftyOne.Pipeline.CloudRequestEngine.Tests/CloudRequestEngineBuilderTests.cs
+++ b/Tests/FiftyOne.Pipeline.CloudRequestEngine.Tests/CloudRequestEngineBuilderTests.cs
@@ -150,14 +150,12 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.Tests
                 .SetResourceKey("abcdefgh")
                 .Build();
 
-            _ = cloudRequestsEngine.PublicProperties;
-
+            // Build warms the engine, so both discovery endpoints have
+            // already been called exactly once.
             VerifyPublicPropsTimes(1);
-
-            _ = cloudRequestsEngine.EvidenceKeyFilter;
-
             VerifyEvidenceKeysTimes(1);
 
+            // Further accesses must not trigger any additional requests.
             _ = cloudRequestsEngine.PublicProperties;
             _ = cloudRequestsEngine.PublicProperties;
             _ = cloudRequestsEngine.EvidenceKeyFilter;
@@ -209,14 +207,12 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.Tests
                 .Build();
 
 
-            _ = cloudRequestsEngine.PublicProperties;
-
+            // Build warms the engine, so both discovery endpoints have
+            // already been called exactly once.
             VerifyPublicPropsTimes(1);
-
-            _ = cloudRequestsEngine.EvidenceKeyFilter;
-
             VerifyEvidenceKeysTimes(1);
 
+            // Further accesses must not trigger any additional requests.
             _ = cloudRequestsEngine.PublicProperties;
             _ = cloudRequestsEngine.PublicProperties;
             _ = cloudRequestsEngine.EvidenceKeyFilter;
@@ -264,14 +260,12 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.Tests
                 .Build();
 
 
-            _ = cloudRequestsEngine.PublicProperties;
-
+            // Build warms the engine, so both discovery endpoints have
+            // already been called exactly once.
             VerifyPublicPropsTimes(1);
-
-            _ = cloudRequestsEngine.EvidenceKeyFilter;
-
             VerifyEvidenceKeysTimes(1);
 
+            // Further accesses must not trigger any additional requests.
             _ = cloudRequestsEngine.PublicProperties;
             _ = cloudRequestsEngine.PublicProperties;
             _ = cloudRequestsEngine.EvidenceKeyFilter;

--- a/Tests/FiftyOne.Pipeline.CloudRequestEngine.Tests/CloudRequestEngineTests.cs
+++ b/Tests/FiftyOne.Pipeline.CloudRequestEngine.Tests/CloudRequestEngineTests.cs
@@ -1426,9 +1426,95 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.Tests
         }
 
         /// <summary>
-        /// Verify that a failure from the evidence keys endpoint also
-        /// causes Build to throw, not just a failure from the accessible
-        /// properties endpoint.
+        /// Verify that a transient failure (5xx) from the discovery
+        /// endpoints does not cause Build to throw, and that the
+        /// discovery requests are retried and succeed when the engine
+        /// is used after the cloud service has recovered.
+        /// </summary>
+        [TestMethod]
+        public void Build_TransientDiscoveryError_ReturnsEngine_AndRetriesOnFirstUse()
+        {
+            string resourceKey = "resource_key";
+
+            _accessiblePropertiesResponseStatus = HttpStatusCode.ServiceUnavailable;
+            _evidenceKeysResponseStatus = HttpStatusCode.ServiceUnavailable;
+
+            ConfigureMockedClient(r => true);
+
+            // Build must succeed despite the cloud service being
+            // temporarily unavailable.
+            var engine = new CloudRequestEngineBuilder(
+                _loggerFactory,
+                _httpClient)
+                .SetResourceKey(resourceKey)
+                .Build();
+
+            Assert.IsNotNull(engine);
+            Assert.IsFalse(engine.IsDisposed);
+            VerifyDiscoveryRequests(Times.Exactly(1));
+
+            // The cloud service comes back up.
+            _accessiblePropertiesResponseStatus = HttpStatusCode.OK;
+            _evidenceKeysResponseStatus = HttpStatusCode.OK;
+
+            // First use must retry the discovery requests and succeed.
+            // Note that Process does not use EvidenceKeyFilter itself
+            // (GetContent sends all evidence), so access both values the
+            // way a consumer such as the web integration would.
+            Assert.IsTrue(engine.PublicProperties.Count > 0);
+            Assert.IsNotNull(engine.EvidenceKeyFilter);
+            using (var pipeline = new PipelineBuilder(_loggerFactory).AddFlowElement(engine).Build())
+            {
+                var data = pipeline.CreateFlowData();
+                data.AddEvidence("query.User-Agent", "iPhone");
+
+                data.Process();
+
+                var result = data.GetFromElement(engine).JsonResponse;
+                Assert.AreEqual("{'device':{'value':'1'}}", result);
+            }
+
+            // One failed attempt at Build plus one successful retry.
+            VerifyDiscoveryRequests(Times.Exactly(2));
+        }
+
+        /// <summary>
+        /// Verify that Build does not throw when the cloud service is
+        /// unreachable at the network level (for example a DNS failure or
+        /// connection refused - the scenario from issue #44), so that a
+        /// temporary cloud outage cannot prevent application startup.
+        /// </summary>
+        [TestMethod]
+        public void Build_CloudUnreachable_ReturnsEngine()
+        {
+            string resourceKey = "resource_key";
+
+            _handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            _handlerMock
+               .Protected()
+               .Setup<Task<HttpResponseMessage>>(
+                  "SendAsync",
+                  ItExpr.Is<HttpRequestMessage>(r => r.Method == HttpMethod.Get),
+                  ItExpr.IsAny<CancellationToken>()
+               )
+               .ThrowsAsync(new HttpRequestException(
+                   "The remote name could not be resolved: 'cloud.51degrees.com'"));
+            _httpClient = new HttpClient(_handlerMock.Object);
+
+            var engine = new CloudRequestEngineBuilder(
+                _loggerFactory,
+                _httpClient)
+                .SetResourceKey(resourceKey)
+                .Build();
+
+            Assert.IsNotNull(engine);
+            Assert.IsFalse(engine.IsDisposed);
+        }
+
+        /// <summary>
+        /// Verify that a definitive failure (4xx) from the evidence keys
+        /// endpoint also causes Build to throw, not just a failure from
+        /// the accessible properties endpoint.
         /// </summary>
         [TestMethod]
         public void Build_EvidenceKeysError_Throws()
@@ -1451,9 +1537,9 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.Tests
         }
 
         /// <summary>
-        /// Verify that when the discovery requests fail, the engine that
-        /// Build created internally is disposed before the exception is
-        /// thrown to the caller.
+        /// Verify that when the discovery requests fail definitively (4xx),
+        /// the engine that Build created internally is disposed before the
+        /// exception is thrown to the caller.
         /// </summary>
         [TestMethod]
         public void Build_Failure_DisposesEngine()

--- a/Tests/FiftyOne.Pipeline.CloudRequestEngine.Tests/CloudRequestEngineTests.cs
+++ b/Tests/FiftyOne.Pipeline.CloudRequestEngine.Tests/CloudRequestEngineTests.cs
@@ -31,6 +31,7 @@ using Moq.Protected;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -534,13 +535,12 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.Tests
 
 
         /// <summary>
-        /// Test cloud request engine handles errors from the cloud service 
+        /// Test cloud request engine handles errors from the cloud service
         /// as expected.
-        /// An AggregateException should be thrown by the cloud request engine
-        /// containing the errors from the cloud service
-        /// and the pipeline is configured to throw any exceptions up 
-        /// the stack in an AggregateException.
-        /// We also check that the exception message includes the content 
+        /// Build performs the discovery requests against the cloud service,
+        /// so a CloudRequestException containing the errors from the cloud
+        /// service should be thrown by Build.
+        /// We also check that the exception message includes the content
         /// from the JSON response.
         /// </summary>
         [TestMethod]
@@ -558,15 +558,13 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.Tests
 
             Exception exception = null;
 
-            var engine = new CloudRequestEngineBuilder(
-                _loggerFactory, 
-                _httpClient)
-                .SetResourceKey(resourceKey)
-                .Build();
-
             try
             {
-                var cloudEngineProps = engine.PublicProperties;
+                var engine = new CloudRequestEngineBuilder(
+                    _loggerFactory,
+                    _httpClient)
+                    .SetResourceKey(resourceKey)
+                    .Build();
             }
             catch (Exception ex)
             {
@@ -679,9 +677,9 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.Tests
         /// <summary>
         /// Test cloud request engine handles a lack of data from the
         /// cloud service as expected.
-        /// An exception should be thrown by the cloud request engine
-        /// and the pipeline is configured to throw any exceptions up
-        /// the stack as an AggregateException.
+        /// Build performs the discovery requests against the cloud service,
+        /// so it should throw a CloudRequestException describing the
+        /// failed properties request.
         /// </summary>
         [TestMethod]
         public void ValidateErrorHandling_NotJson()
@@ -699,15 +697,13 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.Tests
 
             ConfigureMockedClient(_ => true);
 
-            var engine = new CloudRequestEngineBuilder(
-                _loggerFactory,
-                _httpClient)
-                .SetResourceKey(resourceKey)
-                .Build();
-
             var ex = Assert.ThrowsExactly<CloudRequestException>(() =>
             {
-                var cloudEngineProps = engine.PublicProperties;
+                var engine = new CloudRequestEngineBuilder(
+                    _loggerFactory,
+                    _httpClient)
+                    .SetResourceKey(resourceKey)
+                    .Build();
             });
 
             Assert.AreEqual(ex.HttpStatusCode, 404, "Status code should be 404");
@@ -1285,23 +1281,23 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.Tests
         }
 
         /// <summary>
-        /// Check that errors from the cloud service will cause the 
+        /// Check that errors from the cloud service will cause the
         /// appropriate data to be set in the CloudRequestException.
+        /// Build performs the discovery requests against the cloud
+        /// service, so the exception is expected from Build.
         /// </summary>
         [TestMethod]
         public void ValidateErrorHandling_HttpDataSetInException()
         {
             string resourceKey = "resource_key";
 
-            var engine = new CloudRequestEngineBuilder(
-                _loggerFactory, 
-                new HttpClient())
-                .SetResourceKey(resourceKey)
-                .Build();
-
             try
             {
-                var cloudEngineProps = engine.PublicProperties;
+                var engine = new CloudRequestEngineBuilder(
+                    _loggerFactory,
+                    new HttpClient())
+                    .SetResourceKey(resourceKey)
+                    .Build();
                 Assert.Fail("Expected exception did not occur");
             }
             catch (CloudRequestException ex)
@@ -1385,6 +1381,154 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.Tests
                 Assert.IsNotNull(exception, "Expected exception to occur");
                 Assert.IsInstanceOfType<CloudRequestException>(exception);
             }
+        }
+
+        /// <summary>
+        /// Verify that Build fetches the accessible properties and evidence
+        /// keys from the cloud service exactly once, and that processing
+        /// does not trigger any further discovery requests.
+        /// </summary>
+        [TestMethod]
+        public void Build_PerformsDiscovery_ProcessMakesNoFurtherDiscoveryRequests()
+        {
+            string resourceKey = "resource_key";
+            ConfigureMockedClient(r => true);
+
+            var engine = new CloudRequestEngineBuilder(
+                _loggerFactory,
+                _httpClient)
+                .SetResourceKey(resourceKey)
+                .Build();
+
+            // Build must have called each discovery endpoint exactly once.
+            VerifyDiscoveryRequests(Times.Exactly(1));
+
+            using (var pipeline = new PipelineBuilder(_loggerFactory).AddFlowElement(engine).Build())
+            {
+                var data = pipeline.CreateFlowData();
+                data.AddEvidence("query.User-Agent", "iPhone");
+
+                data.Process();
+            }
+
+            // Processing must not have triggered any further discovery
+            // requests.
+            VerifyDiscoveryRequests(Times.Exactly(1));
+            _handlerMock.Protected().Verify(
+               "SendAsync",
+               Times.Exactly(1),
+               ItExpr.Is<HttpRequestMessage>(req =>
+                  req.Method == HttpMethod.Post
+                  && req.RequestUri == expectedUri
+               ),
+               ItExpr.IsAny<CancellationToken>()
+            );
+        }
+
+        /// <summary>
+        /// Verify that a failure from the evidence keys endpoint also
+        /// causes Build to throw, not just a failure from the accessible
+        /// properties endpoint.
+        /// </summary>
+        [TestMethod]
+        public void Build_EvidenceKeysError_Throws()
+        {
+            string resourceKey = "resource_key";
+
+            _evidenceKeysResponse = "Status code: 404, '*evidencekeys' method not found";
+            _evidenceKeysResponseStatus = HttpStatusCode.NotFound;
+
+            ConfigureMockedClient(_ => true);
+
+            Assert.ThrowsExactly<CloudRequestException>(() =>
+            {
+                var engine = new CloudRequestEngineBuilder(
+                    _loggerFactory,
+                    _httpClient)
+                    .SetResourceKey(resourceKey)
+                    .Build();
+            });
+        }
+
+        /// <summary>
+        /// Verify that when the discovery requests fail, the engine that
+        /// Build created internally is disposed before the exception is
+        /// thrown to the caller.
+        /// </summary>
+        [TestMethod]
+        public void Build_Failure_DisposesEngine()
+        {
+            string resourceKey = "resource_key";
+
+            _accessiblePropertiesResponse = @"{ ""errors"":[""resource_key not a valid resource key""]}";
+            _accessiblePropertiesResponseStatus = HttpStatusCode.BadRequest;
+
+            ConfigureMockedClient(_ => true);
+
+            var builder = new EngineCapturingBuilder(
+                _loggerFactory,
+                _httpClient);
+
+            Assert.ThrowsExactly<CloudRequestException>(() =>
+            {
+                var engine = builder
+                    .SetResourceKey(resourceKey)
+                    .Build();
+            });
+
+            Assert.IsNotNull(builder.LastEngine,
+                "The engine should have been created before warmup failed.");
+            Assert.IsTrue(builder.LastEngine.IsDisposed,
+                "The engine should have been disposed when warmup failed.");
+        }
+
+        /// <summary>
+        /// Builder that captures the engine instance it creates so that
+        /// tests can inspect the engine even when Build throws.
+        /// </summary>
+        private class EngineCapturingBuilder : CloudRequestEngineBuilder
+        {
+            public FlowElements.CloudRequestEngine LastEngine { get; private set; }
+
+            public EngineCapturingBuilder(
+                ILoggerFactory loggerFactory,
+                HttpClient httpClient)
+                : base(loggerFactory, httpClient)
+            {
+            }
+
+            protected override FlowElements.CloudRequestEngine NewEngine(
+                List<string> properties)
+            {
+                LastEngine = base.NewEngine(properties);
+                return LastEngine;
+            }
+        }
+
+        /// <summary>
+        /// Verify the number of requests made to each of the two
+        /// discovery endpoints.
+        /// </summary>
+        private void VerifyDiscoveryRequests(Times times)
+        {
+            _handlerMock.Protected().Verify(
+               "SendAsync",
+               times,
+               ItExpr.Is<HttpRequestMessage>(req =>
+                  req.Method == HttpMethod.Get
+                  && req.RequestUri.AbsolutePath.ToLower().EndsWith("accessibleproperties")
+               ),
+               ItExpr.IsAny<CancellationToken>()
+            );
+            _handlerMock.Protected().Verify(
+               "SendAsync",
+               times,
+               ItExpr.Is<HttpRequestMessage>(req =>
+                  req.Method == HttpMethod.Get
+                  && req.RequestUri.AbsolutePath.ToLower().EndsWith("evidencekeys")
+               ),
+               ItExpr.IsAny<CancellationToken>()
+            );
         }
 
         /// <summary>

--- a/Tests/FiftyOne.Pipeline.CloudRequestEngine.Tests/CloudRequestEngineTests.cs
+++ b/Tests/FiftyOne.Pipeline.CloudRequestEngine.Tests/CloudRequestEngineTests.cs
@@ -1512,6 +1512,49 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.Tests
         }
 
         /// <summary>
+        /// Document the interaction between a transient warmup failure and
+        /// an aggressive recovery configuration: the failed warmup attempts
+        /// count towards the failures-to-enter-recovery threshold, so first
+        /// use within the recovery period throws
+        /// <see cref="CloudRequestEngineTemporarilyUnavailableException"/>
+        /// rather than retrying, and the engine heals once the recovery
+        /// period has passed.
+        /// </summary>
+        [TestMethod]
+        public void Build_TransientError_AggressiveRecovery_HealsAfterRecoveryPeriod()
+        {
+            string resourceKey = "resource_key";
+
+            _accessiblePropertiesResponseStatus = HttpStatusCode.ServiceUnavailable;
+            _evidenceKeysResponseStatus = HttpStatusCode.ServiceUnavailable;
+
+            ConfigureMockedClient(r => true);
+
+            var engine = new CloudRequestEngineBuilder(
+                _loggerFactory,
+                _httpClient)
+                .SetResourceKey(resourceKey)
+                .SetRecoverySeconds(0.2)
+                .SetFailuresToEnterRecovery(1)
+                .Build();
+
+            // The cloud service comes back up immediately...
+            _accessiblePropertiesResponseStatus = HttpStatusCode.OK;
+            _evidenceKeysResponseStatus = HttpStatusCode.OK;
+
+            // ...but the engine is still within the recovery period, so
+            // use throws rather than retrying.
+            Assert.ThrowsExactly<CloudRequestEngineTemporarilyUnavailableException>(() =>
+            {
+                var _ = engine.PublicProperties;
+            });
+
+            // Once the recovery period has passed, the engine heals.
+            Thread.Sleep(millisecondsTimeout: 400);
+            Assert.IsTrue(engine.PublicProperties.Count > 0);
+        }
+
+        /// <summary>
         /// Verify that a definitive failure (4xx) from the evidence keys
         /// endpoint also causes Build to throw, not just a failure from
         /// the accessible properties endpoint.


### PR DESCRIPTION
Resolves #312. CloudRequestEngineBuilder.Build() now performs the AccessibleProperties and EvidenceKeys discovery (in parallel) before returning, so the first Process() call no longer pays the cloud round-trip when the cloud is up.

**Warmup failure handling** (reworked after review feedback, to avoid reverting the #44 fix):

- **Definitive configuration errors** — a 4xx response to a discovery request (e.g. invalid resource key) — throw from Build() and dispose the engine. Retrying with the same configuration can never succeed, so this fails fast with a clear stack at startup.
- **Transient failures** — the service unreachable (DNS/connection), timeouts, 5xx responses — log a warning and still return the engine; discovery is retried on first use exactly as before this change. A temporary cloud outage at construction time therefore cannot prevent application startup (the #44 scenario), and SuppressProcessExceptions semantics for Process-time failures are unchanged.

Verified: with the cloud endpoint unreachable, Build() returns the engine in ~2s and the engine recovers on first use once the cloud is back; with an invalid resource key against the real service, Build() throws CloudRequestException. Existing lazy-discovery tests updated; new tests cover single-fetch discovery, 4xx fail-fast (properties and evidence-keys endpoints), dispose-on-fail, 503-at-build-then-recover, and cloud-unreachable-at-build.

Remaining behavioural change to note: configuration errors (4xx) now surface at Build() instead of at the first request. Consumers/CI that build cloud pipelines with dummy resource keys and never call Process() will fail at Build() if the cloud service is reachable and rejects the key.