### PR TITLE
Gate file system watcher on AutoUpdate master switch

### DIFF
--- a/FiftyOne.Pipeline.Engines/Services/DataUpdateService.cs
+++ b/FiftyOne.Pipeline.Engines/Services/DataUpdateService.cs
@@ -258,7 +258,12 @@ namespace FiftyOne.Pipeline.Engines.Services
 					}
 
 					// If file system watcher is enabled then set it up.
-					if (dataFile.Configuration.FileSystemWatcherEnabled &&
+					// AutomaticUpdatesEnabled is the master switch for all
+					// automatic update activity, so the watcher is only created
+					// when auto updates are enabled - the same gate that is
+					// applied to the polling timer above.
+					if (dataFile.AutomaticUpdatesEnabled &&
+						dataFile.Configuration.FileSystemWatcherEnabled &&
 						dataFile.FileWatcher == null &&
 						string.IsNullOrEmpty(dataFile.DataFilePath) == false)
                     {

--- a/Tests/FiftyOne.Pipeline.Engines.Tests/Services/DataUpdateServiceTests.cs
+++ b/Tests/FiftyOne.Pipeline.Engines.Tests/Services/DataUpdateServiceTests.cs
@@ -366,7 +366,10 @@ namespace FiftyOne.Pipeline.Engines.Tests.Services
 
         /// <summary>
         /// Check that enabling the FileSystemWatcher will create a watcher
-        /// and assign it to the configuration object as expected.
+        /// and assign it to the configuration object as expected, but only
+        /// when automatic updates are enabled. AutomaticUpdatesEnabled is the
+        /// master switch for all automatic update activity, so with it disabled
+        /// no watcher is created even if FileSystemWatcherEnabled is true.
         /// </summary>
         [TestMethod]
         [DataRow(true)]
@@ -394,7 +397,18 @@ namespace FiftyOne.Pipeline.Engines.Tests.Services
                 _dataUpdate.RegisterDataFile(file);
 
                 // Assert
-                Assert.IsNotNull(file.FileWatcher);
+                if (autoUpdateEnabled)
+                {
+                    Assert.IsNotNull(file.FileWatcher,
+                        "A file system watcher should be created when automatic " +
+                        "updates are enabled.");
+                }
+                else
+                {
+                    Assert.IsNull(file.FileWatcher,
+                        "No file system watcher should be created when automatic " +
+                        "updates are disabled, as AutoUpdate is the master switch.");
+                }
             }
             finally
             {


### PR DESCRIPTION
### Summary
Make `AutomaticUpdatesEnabled` (AutoUpdate) the master switch for all automatic update activity, so the file system watcher is not created when auto updates are disabled.

Closes #338 

### Problem
Fixes #338. The polling timer in `DataUpdateService.RegisterDataFile` was already gated on `AutomaticUpdatesEnabled`, but the file system watcher was created whenever `FileSystemWatcherEnabled` was true, independent of AutoUpdate. So a data file configured with `AutoUpdate = false` and `FileSystemWatcher = true` still started watching the file on disk. This contradicts the data update specification (see 51Degrees/specifications#21, following 51Degrees/pipeline-java#90) and diverges from pipeline-java, where all registration is gated on auto update.

### Changes
Added `dataFile.AutomaticUpdatesEnabled` to the watcher creation condition in `RegisterDataFile`. Every watcher creation path flows through this block, including the re-entrant `RegisterDataFile` call after a successful update, so the gate holds on refresh as well. Update-on-startup and programmatic update are unaffected, matching the spec's scope (the master switch governs automatic activity only).

### Testing
- Updated the parameterised `DataUpdateService_Register_FileSystemWatcher` test, which previously asserted a watcher was created regardless of AutoUpdate, to expect no watcher when auto updates are disabled and a watcher when they are enabled.

### Risk
Behaviour change only for configurations that set `FileSystemWatcher = true` with `AutoUpdate = false`. Such configurations previously watched the file; now they do not, which is the intended master-switch behaviour and the point of #338. No API surface change.
