### PR TITLE
FEAT: Safe accessors for aspect property values

### DIFF
--- a/FiftyOne.Pipeline.Engines/Data/AspectPropertyValueExtensions.cs
+++ b/FiftyOne.Pipeline.Engines/Data/AspectPropertyValueExtensions.cs
@@ -1,0 +1,222 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+using FiftyOne.Pipeline.Core.Data;
+using System;
+
+namespace FiftyOne.Pipeline.Engines.Data
+{
+    /// <summary>
+    /// Safe accessors for <see cref="IAspectPropertyValue{T}"/> that return
+    /// a fallback instead of throwing when a value cannot be provided.
+    /// </summary>
+    /// <remarks>
+    /// There are two distinct failure modes when reading an aspect
+    /// property, and callers commonly need to treat both as "value
+    /// unknown":
+    /// <list type="number">
+    /// <item><description>
+    /// The property reference resolves but has no value for this
+    /// evidence. <see cref="IAspectPropertyValue.HasValue"/> is false and
+    /// reading <see cref="IAspectPropertyValue{T}.Value"/> throws
+    /// <see cref="Exceptions.NoValueException"/>.
+    /// </description></item>
+    /// <item><description>
+    /// The property reference itself cannot be resolved, for example
+    /// because an upstream cloud request failed or the data file does not
+    /// include the property. The typed property accessor (such as a
+    /// device-data <c>HardwareName</c> getter) throws
+    /// <see cref="PropertyMissingException"/> before any
+    /// <see cref="IAspectPropertyValue{T}"/> instance exists, so
+    /// extensions on the property value cannot guard it. The selector
+    /// overloads below take the accessor as a function and guard the
+    /// whole read.
+    /// </description></item>
+    /// </list>
+    /// </remarks>
+    public static class AspectPropertyValueExtensions
+    {
+        /// <summary>
+        /// True if <paramref name="property"/> is not null and has a value.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type of the value stored in the property.
+        /// </typeparam>
+        /// <param name="property">
+        /// The property value instance to check. May be null.
+        /// </param>
+        /// <returns>
+        /// True when a value can be read, false otherwise.
+        /// </returns>
+        public static bool SafeHasValue<T>(
+            this IAspectPropertyValue<T> property)
+        {
+            try
+            {
+                return property != null && property.HasValue;
+            }
+            catch (PropertyMissingException)
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// The value of <paramref name="property"/>, or
+        /// <paramref name="fallback"/> when the property is null or has
+        /// no value.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type of the value stored in the property.
+        /// </typeparam>
+        /// <param name="property">
+        /// The property value instance to read. May be null.
+        /// </param>
+        /// <param name="fallback">
+        /// The value to return when no value can be read.
+        /// </param>
+        /// <returns>
+        /// The property's value, or <paramref name="fallback"/>.
+        /// </returns>
+        public static T SafeValue<T>(
+            this IAspectPropertyValue<T> property,
+            T fallback = default)
+        {
+            try
+            {
+                return property != null && property.HasValue
+                    ? property.Value
+                    : fallback;
+            }
+            catch (PropertyMissingException)
+            {
+                return fallback;
+            }
+        }
+
+        /// <summary>
+        /// True if the property selected by
+        /// <paramref name="propertySelector"/> can be resolved and has a
+        /// value. Unlike calling <see cref="SafeHasValue{T}"/> on the
+        /// property directly, this guards the resolution of the property
+        /// reference itself, which throws
+        /// <see cref="PropertyMissingException"/> when, for example, an
+        /// upstream cloud request failed.
+        /// </summary>
+        /// <typeparam name="TData">
+        /// The element data type exposing the property.
+        /// </typeparam>
+        /// <typeparam name="TValue">
+        /// The type of the value stored in the property.
+        /// </typeparam>
+        /// <param name="data">
+        /// The element data to read from. May be null.
+        /// </param>
+        /// <param name="propertySelector">
+        /// A function selecting the property to read, for example
+        /// <c>d =&gt; d.HardwareName</c>.
+        /// </param>
+        /// <returns>
+        /// True when a value can be read, false otherwise.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if <paramref name="propertySelector"/> is null.
+        /// </exception>
+        public static bool SafeHasValue<TData, TValue>(
+            this TData data,
+            Func<TData, IAspectPropertyValue<TValue>> propertySelector)
+            where TData : IElementData
+        {
+            if (propertySelector == null)
+            {
+                throw new ArgumentNullException(nameof(propertySelector));
+            }
+            if (data == null)
+            {
+                return false;
+            }
+            try
+            {
+                return propertySelector(data).SafeHasValue();
+            }
+            catch (PropertyMissingException)
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// The value of the property selected by
+        /// <paramref name="propertySelector"/>, or
+        /// <paramref name="fallback"/> when it cannot be provided. Unlike
+        /// calling <see cref="SafeValue{T}"/> on the property directly,
+        /// this guards the resolution of the property reference itself,
+        /// which throws <see cref="PropertyMissingException"/> when, for
+        /// example, an upstream cloud request failed.
+        /// </summary>
+        /// <typeparam name="TData">
+        /// The element data type exposing the property.
+        /// </typeparam>
+        /// <typeparam name="TValue">
+        /// The type of the value stored in the property.
+        /// </typeparam>
+        /// <param name="data">
+        /// The element data to read from. May be null.
+        /// </param>
+        /// <param name="propertySelector">
+        /// A function selecting the property to read, for example
+        /// <c>d =&gt; d.HardwareName</c>.
+        /// </param>
+        /// <param name="fallback">
+        /// The value to return when no value can be read.
+        /// </param>
+        /// <returns>
+        /// The property's value, or <paramref name="fallback"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if <paramref name="propertySelector"/> is null.
+        /// </exception>
+        public static TValue SafeValue<TData, TValue>(
+            this TData data,
+            Func<TData, IAspectPropertyValue<TValue>> propertySelector,
+            TValue fallback = default)
+            where TData : IElementData
+        {
+            if (propertySelector == null)
+            {
+                throw new ArgumentNullException(nameof(propertySelector));
+            }
+            if (data == null)
+            {
+                return fallback;
+            }
+            try
+            {
+                return propertySelector(data).SafeValue(fallback);
+            }
+            catch (PropertyMissingException)
+            {
+                return fallback;
+            }
+        }
+    }
+}

--- a/Tests/FiftyOne.Pipeline.Engines.Tests/Data/AspectPropertyValueExtensionsTests.cs
+++ b/Tests/FiftyOne.Pipeline.Engines.Tests/Data/AspectPropertyValueExtensionsTests.cs
@@ -1,0 +1,165 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+using FiftyOne.Pipeline.Core.Data;
+using FiftyOne.Pipeline.Engines.Data;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+
+namespace FiftyOne.Pipeline.Engines.Tests.Data
+{
+    [TestClass]
+    public class AspectPropertyValueExtensionsTests
+    {
+        /// <summary>
+        /// Element data interface used to exercise the selector overloads,
+        /// mirroring the shape of an engine's typed data (for example
+        /// device data exposing HardwareName).
+        /// </summary>
+        public interface ITestData : IElementData
+        {
+            IAspectPropertyValue<string> Name { get; }
+        }
+
+        /// <summary>
+        /// Check that a populated property returns its value.
+        /// </summary>
+        [TestMethod]
+        public void SafeValue_HasValue_ReturnsValue()
+        {
+            var property = new AspectPropertyValue<string>("abc");
+            Assert.AreEqual("abc", property.SafeValue());
+        }
+
+        /// <summary>
+        /// Check that a property without a value returns the fallback
+        /// rather than throwing NoValueException.
+        /// </summary>
+        [TestMethod]
+        public void SafeValue_NoValue_ReturnsFallback()
+        {
+            var property = new AspectPropertyValue<int>();
+            Assert.AreEqual(5, property.SafeValue(5));
+        }
+
+        /// <summary>
+        /// Check that a null property reference returns the fallback.
+        /// </summary>
+        [TestMethod]
+        public void SafeValue_NullProperty_ReturnsFallback()
+        {
+            IAspectPropertyValue<string> property = null;
+            Assert.AreEqual("fallback", property.SafeValue("fallback"));
+        }
+
+        /// <summary>
+        /// Check that SafeHasValue reflects the underlying HasValue and
+        /// tolerates a null reference.
+        /// </summary>
+        [TestMethod]
+        public void SafeHasValue_States()
+        {
+            Assert.IsTrue(new AspectPropertyValue<int>(1).SafeHasValue());
+            Assert.IsFalse(new AspectPropertyValue<int>().SafeHasValue());
+            IAspectPropertyValue<int> property = null;
+            Assert.IsFalse(property.SafeHasValue());
+        }
+
+        /// <summary>
+        /// Check that the selector overload returns the value when the
+        /// property resolves normally.
+        /// </summary>
+        [TestMethod]
+        public void SafeValue_Selector_ReturnsValue()
+        {
+            var data = new Mock<ITestData>();
+            data.SetupGet(d => d.Name)
+                .Returns(new AspectPropertyValue<string>("abc"));
+
+            Assert.AreEqual("abc", data.Object.SafeValue(d => d.Name));
+        }
+
+        /// <summary>
+        /// Check that the selector overload returns the fallback when
+        /// resolving the property reference itself throws
+        /// PropertyMissingException, the case a direct SafeValue call on
+        /// the property cannot guard because the accessor throws first.
+        /// </summary>
+        [TestMethod]
+        public void SafeValue_SelectorThrowsPropertyMissing_ReturnsFallback()
+        {
+            var data = new Mock<ITestData>();
+            data.SetupGet(d => d.Name)
+                .Throws(new PropertyMissingException("Name is missing"));
+
+            Assert.AreEqual(
+                "fallback",
+                data.Object.SafeValue(d => d.Name, "fallback"));
+        }
+
+        /// <summary>
+        /// Check that the selector overload of SafeHasValue folds a
+        /// PropertyMissingException from the accessor into false.
+        /// </summary>
+        [TestMethod]
+        public void SafeHasValue_SelectorThrowsPropertyMissing_False()
+        {
+            var data = new Mock<ITestData>();
+            data.SetupGet(d => d.Name)
+                .Throws(new PropertyMissingException("Name is missing"));
+
+            Assert.IsFalse(data.Object.SafeHasValue(d => d.Name));
+        }
+
+        /// <summary>
+        /// Check that the selector overloads tolerate null element data.
+        /// </summary>
+        [TestMethod]
+        public void Selector_NullData_Fallback()
+        {
+            ITestData data = null;
+            Assert.AreEqual("fallback", data.SafeValue(d => d.Name, "fallback"));
+            Assert.IsFalse(data.SafeHasValue(d => d.Name));
+        }
+
+        /// <summary>
+        /// Check that a null selector is rejected loudly, as that is a
+        /// programming error rather than a data condition.
+        /// </summary>
+        [TestMethod]
+        public void Selector_NullSelector_Throws()
+        {
+            var data = new Mock<ITestData>();
+            Assert.ThrowsExactly<ArgumentNullException>(() =>
+            {
+                data.Object.SafeValue(
+                    (Func<ITestData, IAspectPropertyValue<string>>)null);
+            });
+            Assert.ThrowsExactly<ArgumentNullException>(() =>
+            {
+                data.Object.SafeHasValue(
+                    (Func<ITestData, IAspectPropertyValue<string>>)null);
+            });
+        }
+    }
+}


### PR DESCRIPTION
Closes #341.

Adds `SafeValue` and `SafeHasValue` extension methods to `FiftyOne.Pipeline.Engines.Data` that fold the two "value unknown" failure modes into a fallback instead of an exception:

- Value-level overloads on `IAspectPropertyValue<T>`: null-safe and `HasValue`-checked, so reading a value-less property returns the fallback instead of throwing `NoValueException`.
- Selector overloads on element data, `data.SafeValue(d => d.HardwareName)` and `data.SafeHasValue(...)`, which additionally guard the resolution of the property reference itself. That accessor throws `PropertyMissingException` (upstream cloud request failed, property not in the data file, or not licensed by the resource key) before any `IAspectPropertyValue<T>` instance exists, so value-level extensions cannot reach it. This is the trap that motivated the change: code guarding `HasValue` looks safe but still throws.

Semantics: data conditions (null property, no value, property missing) return the fallback and never throw; a null selector throws `ArgumentNullException` because that is a programming error.

Motivation: in a production web application using the Pipeline, unguarded reads of this kind converted intermittent cloud request failures into hard 500 responses (see the issue for the exception signature). Contributing the accessors to the Pipeline lets every consumer use them instead of each carrying a local copy.

## Tests

Nine new tests in `Tests/FiftyOne.Pipeline.Engines.Tests/Data/AspectPropertyValueExtensionsTests.cs` covering populated, value-less, and null properties, selector resolution success and `PropertyMissingException`, null element data, and null-selector rejection. Full `FiftyOne.Pipeline.Engines.Tests` suite: 118 passed. Builds clean on both `netstandard2.0` and `net8.0` with `TreatWarningsAsErrors`.
