### PR TITLE
PERF: Remove per-request allocations on the processing hot path

### DIFF
--- a/FiftyOne.Pipeline.CloudRequestEngine/FlowElements/CloudRequestEngine.cs
+++ b/FiftyOne.Pipeline.CloudRequestEngine/FlowElements/CloudRequestEngine.cs
@@ -725,13 +725,18 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.FlowElements
         /// <param name="prefix">The prefix to check for.</param>
         /// <returns>True if the key has the prefix.</returns>
         private static bool KeyHasPrefix(
-            KeyValuePair<string, object> item, 
-            string prefix) 
+            KeyValuePair<string, object> item,
+            string prefix)
         {
-            var key = item.Key.Split(EVIDENCE_SEPARATOR_CHAR_ARRAY);
-            return key[0].Equals(
-                prefix, 
-                StringComparison.InvariantCultureIgnoreCase);
+            // Compare the portion of the key before the first separator
+            // in place, avoiding the string array that Split allocates
+            // for every evidence entry.
+            var key = item.Key;
+            int separatorIndex = key.IndexOfAny(EVIDENCE_SEPARATOR_CHAR_ARRAY);
+            int prefixLength = separatorIndex >= 0 ? separatorIndex : key.Length;
+            return prefixLength == prefix.Length &&
+                string.Compare(key, 0, prefix, 0, prefixLength,
+                    StringComparison.InvariantCultureIgnoreCase) == 0;
         }
 
         /// <summary>
@@ -754,10 +759,16 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.FlowElements
         {
             foreach (var item in evidence)
             {
-                // Get the key parts
-                var key = item.Key.Split(EVIDENCE_SEPARATOR_CHAR_ARRAY, count: 2);
-                var prefix = key[0];
-                var suffix = key.Last();
+                // Get the key parts without allocating the string array
+                // that Split would create for every evidence entry.
+                int separatorIndex =
+                    item.Key.IndexOfAny(EVIDENCE_SEPARATOR_CHAR_ARRAY);
+                var prefix = separatorIndex >= 0
+                    ? item.Key.Substring(0, separatorIndex)
+                    : item.Key;
+                var suffix = separatorIndex >= 0
+                    ? item.Key.Substring(separatorIndex + 1)
+                    : item.Key;
 
                 // Check and add the evidence to the query parameters.
                 if (queryData.ContainsKey(suffix) == false)

--- a/FiftyOne.Pipeline.Core/Data/DataBase.cs
+++ b/FiftyOne.Pipeline.Core/Data/DataBase.cs
@@ -92,22 +92,20 @@ namespace FiftyOne.Pipeline.Core.Data
             }
             set
             {
-                if (_data.ContainsKey(key))
+                // Only pay for the existence check when debug logging
+                // is enabled. Otherwise a single indexer assignment
+                // adds or overwrites with one dictionary lookup.
+                if (_logger != null &&
+                    _logger.IsEnabled(LogLevel.Debug) &&
+                    _data.TryGetValue(key, out var oldValue))
                 {
-                    if (_logger.IsEnabled(LogLevel.Debug))
-                    {
-                        _logger.LogDebug(
-                            $"Data '{GetType().Name}' " +
-                            $"overwriting existing value for '{key}' " +
-                            $"(old value '{AsTruncatedString(_data[key])}', " +
-                            $"new value '{AsTruncatedString(value)}').");
-                    }
-                    _data[key] = value;
+                    _logger.LogDebug(
+                        $"Data '{GetType().Name}' " +
+                        $"overwriting existing value for '{key}' " +
+                        $"(old value '{AsTruncatedString(oldValue)}', " +
+                        $"new value '{AsTruncatedString(value)}').");
                 }
-                else
-                {
-                    _data.Add(key, value);
-                }
+                _data[key] = value;
             }
         }
 

--- a/FiftyOne.Pipeline.Core/TypedMap/TypedKeyMap.cs
+++ b/FiftyOne.Pipeline.Core/TypedMap/TypedKeyMap.cs
@@ -24,7 +24,6 @@ using FiftyOne.Pipeline.Core.Exceptions;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace FiftyOne.Pipeline.Core.TypedMap
 {
@@ -82,14 +81,9 @@ namespace FiftyOne.Pipeline.Core.TypedMap
         /// </param>
         public void Add<T>(ITypedKey<T> key, T data)
         {
-            if (_data.ContainsKey(key.Name) == false)
-            {
-                _data.Add(key.Name, data);
-            }
-            else
-            {
-                _data[key.Name] = data;
-            }
+            // A single indexer assignment adds or overwrites with one
+            // dictionary lookup.
+            _data[key.Name] = data;
         }
 
         /// <summary>
@@ -132,9 +126,8 @@ namespace FiftyOne.Pipeline.Core.TypedMap
             }
 
             T result = default(T);
-            if (_data.ContainsKey(key.Name))
+            if (_data.TryGetValue(key.Name, out object obj))
             {
-                object obj = _data[key.Name];
                 if (obj != null)
                 {
                     result = (T)obj;
@@ -149,29 +142,31 @@ namespace FiftyOne.Pipeline.Core.TypedMap
 
         public T Get<T>()
         {
-            var matches = _data
-                .Where(kvp => kvp.Value.GetType() is T);
-            if (matches.Any() == false)
+            // Iterate the values once, looking for entries that are
+            // assignable to the requested type.
+            object match = null;
+            bool found = false;
+            foreach (var value in _data.Values)
             {
-                matches = _data.Where(kvp => typeof(T)
-                    .IsAssignableFrom(kvp.Value.GetType()));
+                if (value is T)
+                {
+                    if (found)
+                    {
+                        throw new PipelineDataException($"This map contains " +
+                            $"multiple data instances matching type '{typeof(T).Name}'");
+                    }
+                    match = value;
+                    found = true;
+                }
             }
 
-            if (matches.Count() == 1)
-            {
-                return (T)matches.Single().Value;
-            }
-            else if (matches.Any() == false)
+            if (found == false)
             {
                 throw new PipelineDataException(
                     $"This map contains no data matching type " +
                     $"'{typeof(T).Name}'");
             }
-            else
-            {
-                throw new PipelineDataException($"This map contains " +
-                    $"multiple data instances matching type '{typeof(T).Name}'");
-            }
+            return (T)match;
         }
 
         private String GetKeyMissingMessage(string key)

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElement/FlowElement/JavaScriptBuilderElement.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElement/FlowElement/JavaScriptBuilderElement.cs
@@ -484,10 +484,6 @@ namespace FiftyOne.Pipeline.JavaScriptBuilder.FlowElement
                     return WebUtility.UrlEncode(k.Key.Remove(0, dotPos + 1));
                 }, v => WebUtility.UrlEncode(v.Value.ToString()));
 
-            // Serialise the parameters
-            var paramsObject =
-                JsonConvert.SerializeObject(parameters, Formatting.Indented);
-
             return parameters;
         }
 

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JsonBuilderElement/FlowElement/JsonBuilderElement.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JsonBuilderElement/FlowElement/JsonBuilderElement.cs
@@ -414,7 +414,25 @@ namespace FiftyOne.Pipeline.JsonBuilder.FlowElement
         }
 
         /// <summary>
-        /// Build the JSON 
+        /// Shared contract resolver. A single instance is used because
+        /// Json.NET caches the contracts it builds inside the resolver, so
+        /// creating one per request would force it to re-reflect over every
+        /// type on every request. The resolver is thread-safe.
+        /// </summary>
+        private static readonly LowercaseContractResolver CONTRACT_RESOLVER =
+            new LowercaseContractResolver();
+
+        /// <summary>
+        /// Cache for the serializer settings. Item1 is the converter array
+        /// the settings were built from, Item2 the settings. Rebuilt if the
+        /// converter array is replaced (which happens when a new element
+        /// instance is constructed with extra converters).
+        /// </summary>
+        private Tuple<JsonConverter[], JsonSerializerSettings>
+            _serializerSettings;
+
+        /// <summary>
+        /// Build the JSON
         /// </summary>
         /// <param name="allProperties">
         /// A dictionary containing the data to convert to JSON.
@@ -425,16 +443,25 @@ namespace FiftyOne.Pipeline.JsonBuilder.FlowElement
         /// <returns></returns>
         protected virtual string BuildJson(Dictionary<string, object> allProperties)
         {
-            // Build the JSON object from the property list containing property 
+            var converters = JSON_CONVERTERS;
+            var cached = _serializerSettings;
+            if (cached == null ||
+                ReferenceEquals(cached.Item1, converters) == false)
+            {
+                cached = Tuple.Create(converters,
+                    new JsonSerializerSettings
+                    {
+                        ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
+                        Converters = converters,
+                        ContractResolver = CONTRACT_RESOLVER
+                    });
+                _serializerSettings = cached;
+            }
+            // Build the JSON object from the property list containing property
             // values and errors.
             return JsonConvert.SerializeObject(allProperties,
                 Formatting.Indented,
-                new JsonSerializerSettings
-                {
-                    ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
-                    Converters = JSON_CONVERTERS,
-                    ContractResolver = new LowercaseContractResolver()
-                });
+                cached.Item2);
         }
 
         /// <summary>
@@ -525,16 +552,23 @@ namespace FiftyOne.Pipeline.JsonBuilder.FlowElement
 
             Dictionary<string, object> allProperties = new Dictionary<string, object>();
 
-            foreach (var element in data.ElementDataAsDictionary().Where(elementData => 
-                _elementExclusionList.Contains(elementData.Key) == false))
+            foreach (var element in data.ElementDataAsDictionary())
             {
-                if (allProperties.ContainsKey(element.Key.ToLowerInvariant()) == false)
+                if (_elementExclusionList.Contains(element.Key))
+                {
+                    continue;
+                }
+#pragma warning disable CA1308 // Normalize strings to uppercase
+                // Pipeline specification is for keys to be lower-case.
+                var elementKey = element.Key.ToLowerInvariant();
+#pragma warning restore CA1308 // Normalize strings to uppercase
+                if (allProperties.ContainsKey(elementKey) == false)
                 {
                     var values = GetValues(data,
-                        element.Key.ToLowerInvariant(),
+                        elementKey,
                         (element.Value as IElementData).AsDictionary(),
                         config);
-                    allProperties.Add(element.Key.ToLowerInvariant(), values);
+                    allProperties.Add(elementKey, values);
                 }
             }
 

--- a/FiftyOne.Pipeline.Web.Shared/Services/ClientsidePropertyService.cs
+++ b/FiftyOne.Pipeline.Web.Shared/Services/ClientsidePropertyService.cs
@@ -303,7 +303,9 @@ namespace FiftyOne.Pipeline.Web.Shared.Services
                 int length = 0;
                 if (content != null && content.Length > 0)
                 {
-                    length = Encoding.UTF8.GetBytes(content).Length;
+                    // GetByteCount computes the length without allocating
+                    // the byte array that GetBytes would create.
+                    length = Encoding.UTF8.GetByteCount(content);
                 }
 
                 context.Response.StatusCode = 200;


### PR DESCRIPTION
## Summary

Six targeted, low-risk performance fixes on the per-request processing path. No public API changes (verified mechanically, see below) and no behavior changes beyond two benign internal fixes.

### Changes

- **JsonBuilderElement**: share a single `LowercaseContractResolver` and cache the `JsonSerializerSettings` instead of constructing both on every request. Json.NET caches type contracts inside the resolver instance, so a per-call resolver forced full re-reflection over every serialized type on every request.
- **JavaScriptBuilderElement**: remove a dead `JsonConvert.SerializeObject` call in `GetParameters` whose result was never used (the caller serializes again itself).
- **DataBase**: the indexer setter now does a single dictionary write instead of `ContainsKey` plus write, and only pays for the existence check when debug logging is enabled.
- **TypedKeyMap**: single-lookup `Add`/`Get`, and `Get<T>()` rewritten from a LINQ chain that enumerated up to three times into one pass. Also fixes the always-false `kvp.Value.GetType() is T` test and a `NullReferenceException` when the map contains a null value.
- **CloudRequestEngine**: `KeyHasPrefix` and `AddQueryData` no longer call `string.Split`, which allocated three or more string arrays per evidence entry per request. Now index-based, zero allocation.
- **ClientsidePropertyService**: `Encoding.UTF8.GetByteCount(content)` instead of allocating the full `GetBytes` array only to read its length.

### Measurements

Pipeline cycle (create flow data, add evidence, process 3 elements, read result, dispose, 2M iterations, net8.0 Release):

| Metric | main | this PR |
|---|---|---|
| Time per request | ~1,683 ns | ~1,538 ns (**8.6% faster**) |

JSON serialization step in isolation (representative 27-property payload, identical output verified):

| Metric | main pattern | this PR |
|---|---|---|
| Time per call | ~333 us | ~5 us (**~65x faster**) |
| Allocation per call | 42.3 KB | 5.0 KB (**88% less**) |

For web integrations that return the client-side JSON, the serialization saving applies to every such request.

### Compatibility

A reflection dump of every exported type and every public/protected member (2,106 members across Core, Engines, CloudRequestEngine, JsonBuilder, JavaScriptBuilder and Web.Shared) is byte-identical between main and this branch. No binary or source breaking changes.

### Tests

All 874 tests pass locally: Core 271, Engines 109, Engines.FiftyOne 86, CloudRequestEngine 71, JsonBuilder 269, Web.Shared 28, Web 40. (Selenium template tests excluded, they fail on the test machine due to a ChromeDriver/Chrome version mismatch unrelated to this change.)

A follow-up PR will cover allocation reductions on the FlowData lifecycle (lazy stop-token source, cached property projections) which reduce per-request allocations by a further ~10%.