### PR TITLE
Raise default cloud request timeout from 2s to 10s

### DIFF
--- a/FiftyOne.Pipeline.CloudRequestEngine/Constants.cs
+++ b/FiftyOne.Pipeline.CloudRequestEngine/Constants.cs
@@ -94,9 +94,15 @@ namespace FiftyOne.Pipeline.CloudRequestEngine
         public const string CLOUD_REQUEST_ORIGIN_DEFAULT = null;
 
         /// <summary>
-        /// Default timeout when calling cloud service with CloudRequestEngine.
+        /// Default timeout in seconds for a request to the cloud service.
+        /// Set high enough that normal cloud latency is not counted as a
+        /// failure (which would trip the recovery circuit breaker), whilst
+        /// still bounding how long a caller thread can block on a slow or
+        /// unreachable cloud. The circuit breaker
+        /// (see <c>CLOUD_REQUEST_FAILURES_TO_ENTER_RECOVERY_DEFAULT</c>)
+        /// caps thread exposure during a genuine outage.
         /// </summary>
-        public const int CLOUD_REQUEST_TIMEOUT_DEFAULT_SECONDS = 2;
+        public const int CLOUD_REQUEST_TIMEOUT_DEFAULT_SECONDS = 10;
 
         /// <summary>
         /// Default recovery period for CloudRequestEngine

--- a/Tests/FiftyOne.Pipeline.CloudRequestEngine.Tests/CloudRequestEngineBuilderTests.cs
+++ b/Tests/FiftyOne.Pipeline.CloudRequestEngine.Tests/CloudRequestEngineBuilderTests.cs
@@ -275,6 +275,34 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.Tests
             VerifyEvidenceKeysTimes(1);
         }
 
+        /// <summary>
+        /// The default request timeout must not regress into the range
+        /// where ordinary cloud latency is counted as a failure and trips
+        /// the recovery circuit breaker, and it must reach the HttpClient
+        /// when no explicit timeout is configured.
+        /// </summary>
+        [TestMethod]
+        public void Timeout_Default_AppliedToHttpClient()
+        {
+            Assert.IsTrue(
+                Constants.CLOUD_REQUEST_TIMEOUT_DEFAULT_SECONDS >= 5,
+                "The default cloud request timeout is too low; short " +
+                "timeouts turn normal latency into failures that trip the " +
+                "recovery circuit breaker.");
+
+            var httpClient = new HttpClient(_handlerMock.Object);
+
+            _ = new CloudRequestEngineBuilder(new LoggerFactory(), httpClient)
+                .SetResourceKey("abcdefgh")
+                .Build();
+
+            Assert.AreEqual(
+                TimeSpan.FromSeconds(
+                    Constants.CLOUD_REQUEST_TIMEOUT_DEFAULT_SECONDS),
+                httpClient.Timeout,
+                "The default timeout was not applied to the HttpClient.");
+        }
+
         [TestCleanup]
         public void Cleanup()
         {


### PR DESCRIPTION
## Problem

`CloudRequestEngine`'s default request timeout is **2 seconds** (`CLOUD_REQUEST_TIMEOUT_DEFAULT_SECONDS`). The engine records a timed-out request as a failure and feeds it to the recovery circuit breaker introduced in #134: 10 failures within 100s trips it, and the default 60s simple recovery then throws `CloudRequestEngineTemporarilyUnavailableException` on every request for a full minute.

The consequence is that ordinary cloud latency spikes, well within normal operation, get counted as failures. A handful of slow calls trips the breaker, and one trip emits an exception per request for the whole recovery window, so integrators see large exception volumes that scale with their traffic rather than with any real cloud outage.

## History (why it was 2s)

- The default was `HttpClient`'s own **100s** until #134, which introduced the circuit breaker and cut it to **2s** in commit da71f59 with no rationale recorded in the commit or the PR.
- The originating design, issue #132, specified **2 seconds for the RecoveryPeriod**, not for the request timeout. The two values were effectively transposed (the recovery default shipped as 60s, the timeout as 2s).
- Before the breaker existed, a tight 2s timeout was the only lever bounding how long caller threads block on a slow or unreachable cloud (the thread-exhaustion concern that motivated #132). Now that the breaker caps that exposure during a genuine outage, the timeout no longer has to be that aggressive.

## Change

`CLOUD_REQUEST_TIMEOUT_DEFAULT_SECONDS`: **2 to 10**.

Ten seconds still bounds caller-thread blocking on a slow cloud, but sits far enough above normal latency that healthy traffic no longer manufactures breaker trips. Anyone needing a different value can still set it via `SetTimeOutSeconds` / the `TimeOutSeconds` build parameter.

`CloudRequestEngineBuilderTests.Timeout_Default_AppliedToHttpClient` pins the default out of the trip-manufacturing range (asserts >= 5s) and confirms it reaches the `HttpClient` when no explicit timeout is configured. Full `FiftyOne.Pipeline.CloudRequestEngine.Tests` suite passes (78 tests).

## Scope and follow-ups

- This PR changes only the request timeout, the clear root cause. The recovery amplification (a single trip costing 60s of thrown requests) is a separate consideration. Enabling exponential backoff by default, or shortening `CLOUD_REQUEST_RECOVERY_SECONDS_DEFAULT`, would reduce it further but changes breaker behaviour for all integrators, so it is left out of this change for separate discussion.
- `CLOUD_REQUEST_TIMEOUT_DEFAULT_SECONDS` is a `public const`, so assemblies that reference it directly inline the value and keep seeing 2s until recompiled. The common path (`CloudRequestEngineBuilder`) reads it in-assembly, so a package update moves the default for anyone who has not set the timeout explicitly.
- This breaker and its defaults exist only in the .NET port. The other language pipelines (Java, Python, PHP, Node) were noted for porting in #134 but do not carry it yet, so no cross-port default change is needed here.

Refs #132, #134.