### PR TITLE
Make cloud recovery breaker trip only on a sustained failure rate and recover quickly

### DIFF
--- a/FiftyOne.Pipeline.CloudRequestEngine/Constants.cs
+++ b/FiftyOne.Pipeline.CloudRequestEngine/Constants.cs
@@ -94,15 +94,26 @@ namespace FiftyOne.Pipeline.CloudRequestEngine
         public const string CLOUD_REQUEST_ORIGIN_DEFAULT = null;
 
         /// <summary>
-        /// Default timeout when calling cloud service with CloudRequestEngine.
+        /// Default timeout in seconds for a request to the cloud service.
+        /// This bounds how long a caller thread blocks on a slow or
+        /// unreachable cloud, so it is kept low. Because an occasional
+        /// slow request that hits this timeout is counted as a failure,
+        /// the recovery circuit breaker is deliberately insensitive
+        /// (see <c>CLOUD_REQUEST_FAILURES_TO_ENTER_RECOVERY_DEFAULT</c>
+        /// and <c>CLOUD_REQUEST_FAILURES_WINDOW_SECONDS_DEFAULT</c>) so
+        /// that stray timeouts on a healthy cloud do not trip it; only a
+        /// sustained high failure rate, which signals a real outage, does.
         /// </summary>
         public const int CLOUD_REQUEST_TIMEOUT_DEFAULT_SECONDS = 2;
 
         /// <summary>
-        /// Default recovery period for CloudRequestEngine
-        /// once enough requests to server fail in short time.
+        /// Default recovery period in seconds for CloudRequestEngine once
+        /// the failure threshold trips the breaker. Kept short so that a
+        /// trip suppresses requests only briefly before probing the cloud
+        /// again, which bounds both the blackout and the exception volume
+        /// emitted while the breaker is open.
         /// </summary>
-        public const double CLOUD_REQUEST_RECOVERY_SECONDS_DEFAULT = 60.0;
+        public const double CLOUD_REQUEST_RECOVERY_SECONDS_DEFAULT = 10.0;
 
         /// <summary>
         /// Whether exponential backoff is enabled by default.
@@ -134,20 +145,28 @@ namespace FiftyOne.Pipeline.CloudRequestEngine
         /// Maximal number of failures to occur within some time
         /// for CloudRequestEngine to temporarily stop sending requests.
         /// </summary>
-        public const int CLOUD_REQUEST_FAILURES_TO_ENTER_RECOVERY_MAX = 100;
+        public const int CLOUD_REQUEST_FAILURES_TO_ENTER_RECOVERY_MAX = 1000;
 
         /// <summary>
-        /// Minimal number of failures to occur within some time
-        /// for CloudRequestEngine to temporarily stop sending requests.
+        /// Default number of failures that must occur within
+        /// <see cref="CLOUD_REQUEST_FAILURES_WINDOW_SECONDS_DEFAULT"/>
+        /// for CloudRequestEngine to enter its recovery period. Set high
+        /// so that stray request timeouts on an otherwise healthy cloud
+        /// do not trip the breaker; reaching this many failures in the
+        /// window signals that the cloud is genuinely unavailable rather
+        /// than occasionally slow.
         /// </summary>
-        public const int CLOUD_REQUEST_FAILURES_TO_ENTER_RECOVERY_DEFAULT = 10;
+        public const int CLOUD_REQUEST_FAILURES_TO_ENTER_RECOVERY_DEFAULT = 100;
 
         /// <summary>
-        /// Default time period in seconds within which a number of
-        /// failed requests should reach `FailuresToEnterRecovery`
-        /// for CloudRequestEngine to enter "recovery period"
+        /// Default time period in seconds within which
+        /// <see cref="CLOUD_REQUEST_FAILURES_TO_ENTER_RECOVERY_DEFAULT"/>
+        /// failed requests must occur for CloudRequestEngine to enter its
+        /// recovery period. A short window means the threshold reflects a
+        /// failure rate (a burst of failures signalling an outage) rather
+        /// than failures accumulated slowly over a long period.
         /// </summary>
-        public const int CLOUD_REQUEST_FAILURES_WINDOW_SECONDS_DEFAULT = 100;
+        public const int CLOUD_REQUEST_FAILURES_WINDOW_SECONDS_DEFAULT = 10;
 
     }
 }

--- a/FiftyOne.Pipeline.CloudRequestEngine/Constants.cs
+++ b/FiftyOne.Pipeline.CloudRequestEngine/Constants.cs
@@ -116,19 +116,29 @@ namespace FiftyOne.Pipeline.CloudRequestEngine
         public const double CLOUD_REQUEST_RECOVERY_SECONDS_DEFAULT = 10.0;
 
         /// <summary>
-        /// Whether exponential backoff is enabled by default.
+        /// Whether exponential backoff is enabled by default. Enabled so
+        /// that after a trip the breaker probes the cloud again quickly
+        /// (see the initial delay below) rather than sitting in a fixed
+        /// <see cref="CLOUD_REQUEST_RECOVERY_SECONDS_DEFAULT"/> blackout,
+        /// backing off further only if the outage persists. When this is
+        /// true the simple <see cref="CLOUD_REQUEST_RECOVERY_SECONDS_DEFAULT"/>
+        /// period is not used.
         /// </summary>
-        public const bool CLOUD_REQUEST_EXPONENTIAL_BACKOFF_ENABLED_DEFAULT = false;
+        public const bool CLOUD_REQUEST_EXPONENTIAL_BACKOFF_ENABLED_DEFAULT = true;
 
         /// <summary>
         /// Default initial delay in seconds for exponential backoff recovery.
+        /// The first recovery probe after a trip happens this soon, so a
+        /// brief cloud blip clears quickly.
         /// </summary>
         public const double CLOUD_REQUEST_EXPONENTIAL_BACKOFF_INITIAL_DELAY_SECONDS_DEFAULT = 2.0;
 
         /// <summary>
         /// Default maximum delay in seconds for exponential backoff recovery.
+        /// Caps how long the breaker stays suppressed between probes so a
+        /// prolonged outage never parks recovery for long.
         /// </summary>
-        public const double CLOUD_REQUEST_EXPONENTIAL_BACKOFF_MAX_DELAY_SECONDS_DEFAULT = 300.0;
+        public const double CLOUD_REQUEST_EXPONENTIAL_BACKOFF_MAX_DELAY_SECONDS_DEFAULT = 10.0;
 
         /// <summary>
         /// Default multiplier for exponential backoff recovery.

--- a/Tests/FiftyOne.Pipeline.CloudRequestEngine.Tests/CloudRequestEngineBuilderTests.cs
+++ b/Tests/FiftyOne.Pipeline.CloudRequestEngine.Tests/CloudRequestEngineBuilderTests.cs
@@ -22,6 +22,8 @@
 
 using FiftyOne.Pipeline.CloudRequestEngine.FlowElements;
 using FiftyOne.Pipeline.Core.Exceptions;
+using FiftyOne.Pipeline.Core.FailHandling.Facade;
+using FiftyOne.Pipeline.Core.FailHandling.Recovery;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -30,6 +32,7 @@ using System;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -312,6 +315,56 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.Tests
                 .SetFailuresToEnterRecovery(
                     Constants.CLOUD_REQUEST_FAILURES_TO_ENTER_RECOVERY_DEFAULT)
                 .Build();
+        }
+
+        /// <summary>
+        /// By default a tripped breaker must recover with exponential
+        /// backoff (probe again quickly, back off only if the outage
+        /// persists) rather than a fixed blackout, and the backoff must be
+        /// capped so it never stays suppressed for long.
+        /// </summary>
+        [TestMethod]
+        public void ExponentialBackoff_IsDefault_WithCappedDelay()
+        {
+            Assert.IsTrue(
+                Constants.CLOUD_REQUEST_EXPONENTIAL_BACKOFF_ENABLED_DEFAULT,
+                "Exponential backoff should be the default recovery strategy.");
+            Assert.IsTrue(
+                Constants.CLOUD_REQUEST_EXPONENTIAL_BACKOFF_MAX_DELAY_SECONDS_DEFAULT
+                    <= 10,
+                "The default maximum backoff delay is too long; recovery " +
+                "should never stay suppressed for long.");
+
+            var engine = new CloudRequestEngineBuilder(
+                    new LoggerFactory(), new HttpClient(_handlerMock.Object))
+                .SetResourceKey("abcdefgh")
+                .Build();
+
+            var failHandler = GetPrivateField<IFailHandler>(
+                engine, "_failHandler");
+            var strategy = GetPrivateField<IRecoveryStrategy>(
+                failHandler, "_recoveryStrategy");
+            Assert.IsInstanceOfType<ExponentialBackoffRecoveryStrategy>(
+                strategy,
+                "The default recovery strategy should be exponential backoff.");
+            var backoff = (ExponentialBackoffRecoveryStrategy)strategy;
+            Assert.AreEqual(
+                Constants.CLOUD_REQUEST_EXPONENTIAL_BACKOFF_INITIAL_DELAY_SECONDS_DEFAULT,
+                backoff.InitialDelaySeconds);
+            Assert.AreEqual(
+                Constants.CLOUD_REQUEST_EXPONENTIAL_BACKOFF_MAX_DELAY_SECONDS_DEFAULT,
+                backoff.MaxDelaySeconds);
+        }
+
+        private static T GetPrivateField<T>(object instance, string fieldName)
+        {
+            var field = instance.GetType().GetField(
+                fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.IsNotNull(
+                field,
+                $"Field '{fieldName}' not found on " +
+                $"{instance.GetType().Name}; pipeline internals changed.");
+            return (T)field.GetValue(instance);
         }
 
         [TestCleanup]

--- a/Tests/FiftyOne.Pipeline.CloudRequestEngine.Tests/CloudRequestEngineBuilderTests.cs
+++ b/Tests/FiftyOne.Pipeline.CloudRequestEngine.Tests/CloudRequestEngineBuilderTests.cs
@@ -275,6 +275,45 @@ namespace FiftyOne.Pipeline.CloudRequestEngine.Tests
             VerifyEvidenceKeysTimes(1);
         }
 
+        /// <summary>
+        /// The default circuit breaker sensitivity must stay in the range
+        /// that only trips on a genuine outage: a high failure count over a
+        /// short window (a failure rate), not a low count over a long one.
+        /// The default count must also remain a configurable value (within
+        /// the allowed min/max), not sit on the ceiling.
+        /// </summary>
+        [TestMethod]
+        public void FailuresToEnterRecovery_Defaults_RequireSustainedFailureRate()
+        {
+            Assert.IsTrue(
+                Constants.CLOUD_REQUEST_FAILURES_TO_ENTER_RECOVERY_DEFAULT >= 100,
+                "The default failure count is too low; a small count lets " +
+                "stray timeouts on a healthy cloud trip the breaker.");
+            Assert.IsTrue(
+                Constants.CLOUD_REQUEST_FAILURES_WINDOW_SECONDS_DEFAULT <= 10,
+                "The default window is too long; a long window lets failures " +
+                "accumulate slowly rather than requiring an outage-like rate.");
+            Assert.IsTrue(
+                Constants.CLOUD_REQUEST_FAILURES_TO_ENTER_RECOVERY_DEFAULT
+                    < Constants.CLOUD_REQUEST_FAILURES_TO_ENTER_RECOVERY_MAX,
+                "The default failure count must leave headroom below the " +
+                "maximum so a less sensitive breaker can still be configured.");
+            Assert.IsTrue(
+                Constants.CLOUD_REQUEST_RECOVERY_SECONDS_DEFAULT <= 10,
+                "The default recovery period is too long; a trip should " +
+                "suppress requests only briefly before probing the cloud again.");
+
+            // The default must be a value the builder accepts (does not
+            // exceed the max), so an engine can be built without overriding
+            // it.
+            _ = new CloudRequestEngineBuilder(
+                    new LoggerFactory(), new HttpClient(_handlerMock.Object))
+                .SetResourceKey("abcdefgh")
+                .SetFailuresToEnterRecovery(
+                    Constants.CLOUD_REQUEST_FAILURES_TO_ENTER_RECOVERY_DEFAULT)
+                .Build();
+        }
+
         [TestCleanup]
         public void Cleanup()
         {

--- a/Tests/FiftyOne.Pipeline.CloudRequestEngine.Tests/CloudRequestEngineTests.cs
+++ b/Tests/FiftyOne.Pipeline.CloudRequestEngine.Tests/CloudRequestEngineTests.cs
@@ -789,6 +789,7 @@ cloudEx.Message, "Exception message did not contain the expected text.");
                 _loggerFactory,
                 _httpClient)
                 .SetResourceKey(resourceKey)
+                .SetUseExponentialBackoff(false)
                 .SetRecoverySeconds(0.1)
                 .SetFailuresToEnterRecovery(1)
                 .Build();
@@ -860,6 +861,7 @@ cloudEx.Message, "Exception message did not contain the expected text.");
                 _loggerFactory,
                 _httpClient)
                 .SetResourceKey(resourceKey)
+                .SetUseExponentialBackoff(false)
                 .SetRecoverySeconds(0.1)
                 .SetFailuresToEnterRecovery(1)
                 .Build();
@@ -930,6 +932,7 @@ cloudEx.Message, "Exception message did not contain the expected text.");
                 _loggerFactory,
                 _httpClient)
                 .SetResourceKey(resourceKey)
+                .SetUseExponentialBackoff(false)
                 .SetRecoverySeconds(0.3)
                 .SetFailuresToEnterRecovery(1)
                 .Build();
@@ -1914,6 +1917,7 @@ cloudEx.Message, "Exception message did not contain the expected text.");
                 _loggerFactory,
                 _httpClient)
                 .SetResourceKey(resourceKey)
+                .SetUseExponentialBackoff(false)
                 .SetRecoverySeconds(0.2)
                 .SetFailuresToEnterRecovery(1)
                 .Build();

--- a/Tests/FiftyOne.Pipeline.CloudRequestEngine.Tests/CloudRequestEngineTests.cs
+++ b/Tests/FiftyOne.Pipeline.CloudRequestEngine.Tests/CloudRequestEngineTests.cs
@@ -1006,6 +1006,100 @@ cloudEx.Message, "Exception message did not contain the expected text.");
         }
 
         /// <summary>
+        /// Reproduce the full circuit-breaker cycle on the per-request
+        /// (Process) path with the exponential backoff recovery strategy
+        /// enabled, which is the configuration a consumer turns on to
+        /// shorten the recovery blackout.
+        ///
+        /// <para>
+        /// Simulate a cloud failure, confirm one failure trips the
+        /// breaker, confirm that a request made while the breaker is open
+        /// is suppressed (throws without making any HTTP call, which is
+        /// what stops a single trip flooding logs and parking threads),
+        /// and confirm the engine comes back alive once the backoff delay
+        /// has elapsed and the cloud is healthy again.
+        /// </para>
+        /// </summary>
+        [TestMethod]
+        public void ExponentialBackoff_TripsThenRecoversAfterDelay()
+        {
+            string resourceKey = "resource_key";
+            string userAgent = "iPhone";
+            const double initialDelaySeconds = 0.5;
+
+            ConfigureMockedClient(_ => true);
+
+            // Warmup discovery succeeds, so the engine builds cleanly and
+            // only the per-request json call fails below.
+            var engine = new CloudRequestEngineBuilder(
+                _loggerFactory,
+                _httpClient)
+                .SetResourceKey(resourceKey)
+                .SetUseExponentialBackoff(true)
+                .SetExponentialBackoffInitialDelay(initialDelaySeconds)
+                .SetExponentialBackoffMaxDelay(30)
+                .SetExponentialBackoffMultiplier(2)
+                .SetFailuresToEnterRecovery(1)
+                .Build();
+
+            using var pipeline = new PipelineBuilder(_loggerFactory)
+                .AddFlowElement(engine).Build();
+
+            void Process()
+            {
+                using var flowData = pipeline.CreateFlowData();
+                flowData.AddEvidence("query.User-Agent", userAgent);
+                flowData.Process();
+            }
+
+            // The cloud starts failing every per-request json call.
+            _jsonResponse = "Status code: 503, service unavailable";
+            _jsonResponseStatus = HttpStatusCode.ServiceUnavailable;
+
+            // First request is attempted, fails, and trips the breaker.
+            var firstError = Assert.ThrowsExactly<AggregateException>(Process);
+            Assert.IsNotInstanceOfType<PipelineTemporarilyUnavailableException>(
+                firstError.InnerException,
+                "The first failure should be the real cloud error, not a " +
+                "suppression, because the breaker is not open yet.");
+            VerifyJsonPosts(Times.Exactly(1));
+
+            // While the breaker is open, a request is short-circuited: it
+            // throws PipelineTemporarilyUnavailableException and makes no
+            // HTTP call (the json POST count stays at one).
+            var suppressed = Assert.ThrowsExactly<AggregateException>(Process);
+            Assert.IsInstanceOfType<PipelineTemporarilyUnavailableException>(
+                suppressed.InnerException,
+                "A request during the recovery window should be suppressed.");
+            VerifyJsonPosts(Times.Exactly(1));
+
+            // The cloud recovers, but the engine stays suppressed until the
+            // backoff delay elapses.
+            _jsonResponse = "{'device':{'value':'1'}}";
+            _jsonResponseStatus = HttpStatusCode.OK;
+
+            Thread.Sleep(TimeSpan.FromSeconds(initialDelaySeconds + 0.3));
+
+            // After the delay the engine comes back alive: the request is
+            // attempted again (a second json POST) and succeeds.
+            Process();
+            VerifyJsonPosts(Times.Exactly(2));
+        }
+
+        private void VerifyJsonPosts(Times times)
+        {
+            _handlerMock.Protected().Verify(
+               "SendAsync",
+               times,
+               ItExpr.Is<HttpRequestMessage>(req =>
+                  req.Method == HttpMethod.Post
+                  && req.RequestUri.AbsolutePath.ToLower().EndsWith("json")
+               ),
+               ItExpr.IsAny<CancellationToken>()
+            );
+        }
+
+        /// <summary>
         /// Verify that the 'DelayExecution' and 'EvidenceProperties'
         /// properties are populated correctly by the CloudRequestEngine.
         /// </summary>

--- a/Tests/FiftyOne.Pipeline.Core.Tests/FailHandling/WindowedFailHandlerTests.cs
+++ b/Tests/FiftyOne.Pipeline.Core.Tests/FailHandling/WindowedFailHandlerTests.cs
@@ -1,0 +1,132 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+using FiftyOne.Pipeline.Core.FailHandling.Facade;
+using FiftyOne.Pipeline.Core.FailHandling.Recovery;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Threading;
+
+namespace FiftyOne.Pipeline.Core.Tests
+{
+    /// <summary>
+    /// Tests the trip semantics of <see cref="WindowedFailHandler"/>: the
+    /// breaker enters recovery only when the configured number of failures
+    /// occurs within the configured window (a failure rate), which is what
+    /// keeps stray failures on a healthy cloud from tripping it.
+    /// </summary>
+    [TestClass]
+    public class WindowedFailHandlerTests
+    {
+        // Long enough that a recorded failure keeps the strategy suppressing
+        // for the whole test once the threshold trips it.
+        private static SimpleRecoveryStrategy AlwaysSuppressAfterFailure
+            => new SimpleRecoveryStrategy(recoverySeconds: 100);
+
+        private static WindowedFailHandler MakeHandler(
+            int threshold, TimeSpan window, IRecoveryStrategy strategy)
+            => new WindowedFailHandler(
+                strategy, threshold, window, NullLogger.Instance, "test");
+
+        private static void RecordFailure(WindowedFailHandler handler)
+        {
+            using var scope = handler.MakeAttemptScope();
+            scope.RecordFailure(new Exception("simulated cloud failure"));
+        }
+
+        /// <summary>
+        /// True if the handler is currently suppressing requests (the
+        /// breaker is open). CheckIfRecovered throws the exception the
+        /// factory returns while suppressing, and returns true otherwise.
+        /// </summary>
+        private static bool IsSuppressing(WindowedFailHandler handler)
+        {
+            try
+            {
+                handler.CheckIfRecovered(
+                    (msg, ex) => new InvalidOperationException(msg, ex));
+                return false;
+            }
+            catch (InvalidOperationException)
+            {
+                return true;
+            }
+        }
+
+        [TestMethod]
+        public void DoesNotTripBelowThreshold_TripsAtThreshold()
+        {
+            const int threshold = 5;
+            var handler = MakeHandler(
+                threshold,
+                TimeSpan.FromSeconds(100),
+                AlwaysSuppressAfterFailure);
+
+            for (int i = 1; i < threshold; i++)
+            {
+                RecordFailure(handler);
+                Assert.IsFalse(
+                    IsSuppressing(handler),
+                    $"Breaker tripped after only {i} of {threshold} failures.");
+            }
+
+            RecordFailure(handler);
+            Assert.IsTrue(
+                IsSuppressing(handler),
+                "Breaker did not trip once the failure threshold was reached.");
+        }
+
+        [TestMethod]
+        public void FailuresSpreadBeyondWindowDoNotAccumulate()
+        {
+            const int threshold = 3;
+            var window = TimeSpan.FromSeconds(1);
+            var handler = MakeHandler(
+                threshold, window, AlwaysSuppressAfterFailure);
+
+            // Two failures inside the window: below threshold, no trip.
+            RecordFailure(handler);
+            RecordFailure(handler);
+            Assert.IsFalse(IsSuppressing(handler));
+
+            // Let those age out of the window.
+            Thread.Sleep(TimeSpan.FromSeconds(1.3));
+
+            // Two fresh failures: the aged-out ones must not count, so the
+            // in-window total is two, still below the threshold.
+            RecordFailure(handler);
+            RecordFailure(handler);
+            Assert.IsFalse(
+                IsSuppressing(handler),
+                "Failures spread beyond the window accumulated to the " +
+                "threshold; the window is not being applied.");
+
+            // A third fresh failure reaches the threshold within the window.
+            RecordFailure(handler);
+            Assert.IsTrue(
+                IsSuppressing(handler),
+                "Breaker did not trip once the threshold was reached within " +
+                "the window.");
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`CloudRequestEngine`'s recovery circuit breaker enters recovery after **10 failed requests within a 100 second window**, then suppresses all requests for **60 seconds**. A failed request includes one that merely exceeded the 2 second request timeout, so that threshold is low enough for ordinary latency spikes on a healthy cloud to trip it. The 60 second blackout then surfaces `CloudRequestEngineTemporarilyUnavailableException` on every request for a full minute, producing large exception volumes even though the cloud service is up. This is what integrators see as "the cloud is not down but we get floods of temporarily-unavailable exceptions".

## Change

Retune the breaker so it fires only on a failure *rate* that signals a genuine outage, and so a trip recovers quickly:

| Constant | Old | New |
|---|---|---|
| `CLOUD_REQUEST_FAILURES_TO_ENTER_RECOVERY_DEFAULT` | 10 | **100** |
| `CLOUD_REQUEST_FAILURES_WINDOW_SECONDS_DEFAULT` | 100 | **10** |
| `CLOUD_REQUEST_EXPONENTIAL_BACKOFF_ENABLED_DEFAULT` | false | **true** |
| `CLOUD_REQUEST_EXPONENTIAL_BACKOFF_MAX_DELAY_SECONDS_DEFAULT` | 300 | **10** |
| `CLOUD_REQUEST_RECOVERY_SECONDS_DEFAULT` | 60 | **10** |
| `CLOUD_REQUEST_FAILURES_TO_ENTER_RECOVERY_MAX` | 100 | **1000** |

**Trip condition:** recovery now engages only when 100 requests fail within 10 seconds.

**Recovery:** exponential backoff is now the default strategy, so after a trip the breaker probes the cloud again after a 2 second initial delay (the existing `INITIAL_DELAY` default) rather than a fixed blackout, and backs off only if the outage persists, capped at 10 seconds. The simple `RECOVERY_SECONDS` default is lowered to 10 too, but it is used only when a consumer explicitly disables backoff. `MAX` is raised so the new failure-count default is a configurable value rather than sitting on the ceiling.

**The request timeout default is deliberately left at 2s.** It already bounds how long any single caller thread blocks on a slow or unreachable cloud (the thread-exhaustion concern from #132), so relaxing the breaker does not reintroduce that exposure. The breaker's job is narrowed to detecting a real outage, not reacting to intermittent slowness.

## Tests

- `WindowedFailHandlerTests` (new): proves the breaker does not trip below the threshold, trips once it is reached within the window, and does not accumulate failures that are spread beyond the window - the direct proof of the "N failures within the window" semantic.
- `CloudRequestEngineTests.ExponentialBackoff_TripsThenRecoversAfterDelay` (new): reproduces the full cycle end to end against a mocked handler - simulated failures trip the breaker, a request while it is open is suppressed and makes no HTTP call, and it comes back alive once the recovery delay elapses.
- `CloudRequestEngineBuilderTests`: guards the new default sensitivity and recovery period, and that exponential backoff is the default strategy with the capped delay.
- The existing simple-recovery cycle tests now set `SetUseExponentialBackoff(false)` to keep exercising the fixed-recovery path, since backoff is now the default.

Full `FiftyOne.Pipeline.CloudRequestEngine.Tests` (80) and `FiftyOne.Pipeline.Core.Tests` FailHandling (22) pass locally; timing-sensitive tests run repeatedly without flaking.

## Trade-off to note

100 failures in 10 seconds is a rate of 10 failures/sec. An integration whose throughput through the pipeline is below that rate will not trip the breaker even during a total outage; with the 2s timeout bounding each request, those requests simply fail individually instead. This is intended (the breaker reacts only to genuine outages), but integrators running low traffic who want earlier tripping can lower `FailuresToEnterRecovery` / widen `FailuresWindowSeconds`.

## Note

`CLOUD_REQUEST_*` are `public const`, so assemblies that reference them directly inline the values until recompiled; the common `CloudRequestEngineBuilder` path reads them in-assembly, so a package update moves the defaults for anyone not overriding them. This breaker exists only in the .NET port.

Refs #132, #134. Mirrored on the website side by 51Degrees/Website#884.
