### PR TITLE
Update Selenium.WebDriver to 4.46.0

### DIFF
--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/FiftyOne.Pipeline.JavaScriptBuilderElementTests.csproj
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JavaScriptBuilderElementTests/FiftyOne.Pipeline.JavaScriptBuilderElementTests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
-    <PackageReference Include="Selenium.WebDriver" Version="4.38.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.46.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Aligned Selenium update across repos: old Selenium releases bundle a Selenium Manager that can pair a stale cached ChromeDriver with a newer Chrome on CI runners, failing browser tests with SessionNotCreatedException (hit by the pipeline-java nightly, run 29470481774; fixed there in 51Degrees/pipeline-java#104). Bumps Selenium.WebDriver 4.38.0 to 4.46.0 in FiftyOne.Pipeline.JavaScriptBuilderElementTests. Part of #TASK.