### PR TITLE
FIX: Don't log element errors as errors when suppressing (#280)

### DIFF
--- a/FiftyOne.Pipeline.Core/FlowElements/IPipeline.cs
+++ b/FiftyOne.Pipeline.Core/FlowElements/IPipeline.cs
@@ -68,6 +68,10 @@ namespace FiftyOne.Pipeline.Core.FlowElements
         /// When true, exceptions thrown by flow elements are also not logged
         /// at error level. They are logged at debug level instead and remain
         /// available through <see cref="IFlowData.Errors"/>.
+        /// This applies to exceptions that a flow element allows to escape
+        /// its Process method. Errors that an element records itself by
+        /// calling AddError on the flow data are logged as that element
+        /// requests, regardless of this setting.
         /// </summary>
         bool SuppressProcessExceptions { get; }
 

--- a/FiftyOne.Pipeline.Core/FlowElements/IPipeline.cs
+++ b/FiftyOne.Pipeline.Core/FlowElements/IPipeline.cs
@@ -65,6 +65,9 @@ namespace FiftyOne.Pipeline.Core.FlowElements
         /// Control field that indicates if the Pipeline will throw an
         /// aggregate exception during processing or suppress it and ignore the
         /// exceptions added to <see cref="IFlowData.Errors"/>.
+        /// When true, exceptions thrown by flow elements are also not logged
+        /// at error level. They are logged at debug level instead and remain
+        /// available through <see cref="IFlowData.Errors"/>.
         /// </summary>
         bool SuppressProcessExceptions { get; }
 

--- a/FiftyOne.Pipeline.Core/FlowElements/ParallelElements.cs
+++ b/FiftyOne.Pipeline.Core/FlowElements/ParallelElements.cs
@@ -143,6 +143,9 @@ namespace FiftyOne.Pipeline.Core.FlowElements
                             // skipped when the pipeline suppresses process
                             // exceptions. The error remains available through
                             // IFlowData.Errors and is logged at debug level.
+                            // Pipeline is never null on a flow data created by
+                            // a pipeline, but stub implementations can leave it
+                            // unset, so treat that as 'do not suppress'.
                             var suppress =
                                 data.Pipeline?.SuppressProcessExceptions ?? false;
                             foreach (var innerException in t.Exception.InnerExceptions)
@@ -151,7 +154,7 @@ namespace FiftyOne.Pipeline.Core.FlowElements
                                 if (suppress && Logger.IsEnabled(LogLevel.Debug))
                                 {
                                     Logger.LogDebug(innerException,
-                                        $"Suppressed error during processing of " +
+                                        "Suppressed error during processing of " +
                                         $"'{element?.GetType().Name}'.");
                                 }
                             }

--- a/FiftyOne.Pipeline.Core/FlowElements/ParallelElements.cs
+++ b/FiftyOne.Pipeline.Core/FlowElements/ParallelElements.cs
@@ -139,9 +139,21 @@ namespace FiftyOne.Pipeline.Core.FlowElements
                         // flow data.
                         if (t.Exception != null)
                         {
+                            // As in Pipeline.Process, error level logging is
+                            // skipped when the pipeline suppresses process
+                            // exceptions. The error remains available through
+                            // IFlowData.Errors and is logged at debug level.
+                            var suppress =
+                                data.Pipeline?.SuppressProcessExceptions ?? false;
                             foreach (var innerException in t.Exception.InnerExceptions)
                             {
-                                data.AddError(innerException, element);
+                                data.AddError(innerException, element, true, !suppress);
+                                if (suppress && Logger.IsEnabled(LogLevel.Debug))
+                                {
+                                    Logger.LogDebug(innerException,
+                                        $"Suppressed error during processing of " +
+                                        $"'{element?.GetType().Name}'.");
+                                }
                             }
                         }
                     }, TaskScheduler.Default));

--- a/FiftyOne.Pipeline.Core/FlowElements/Pipeline.cs
+++ b/FiftyOne.Pipeline.Core/FlowElements/Pipeline.cs
@@ -183,6 +183,10 @@ namespace FiftyOne.Pipeline.Core.FlowElements
         /// When true, exceptions thrown by flow elements are also not logged
         /// at error level. They are logged at debug level instead and remain
         /// available through <see cref="IFlowData.Errors"/>.
+        /// This applies to exceptions that a flow element allows to escape
+        /// its Process method. Errors that an element records itself by
+        /// calling AddError on the flow data are logged as that element
+        /// requests, regardless of this setting.
         /// </summary>
         public bool SuppressProcessExceptions => _suppressProcessExceptions;
 
@@ -385,6 +389,13 @@ namespace FiftyOne.Pipeline.Core.FlowElements
         /// Thrown if an error occurred during processing, 
         /// unless <see ref="SuppressProcessExceptions"/> is true.
         /// </exception>
+        /// <remarks>
+        /// If <see ref="SuppressProcessExceptions"/> is true then exceptions
+        /// thrown by elements are logged at debug rather than error level.
+        /// They are always added to <see cref="IFlowData.Errors"/>.
+        /// Errors that an element records itself by calling AddError on the
+        /// flow data are not affected by this setting.
+        /// </remarks>
         public void Process(IFlowData data)
         {
             if(data == null)
@@ -429,7 +440,7 @@ namespace FiftyOne.Pipeline.Core.FlowElements
                         _logger.IsEnabled(LogLevel.Debug))
                     {
                         _logger.LogDebug(ex,
-                            $"Suppressed error during processing of " +
+                            "Suppressed error during processing of " +
                             $"'{element?.GetType().Name}'.");
                     }
                 }

--- a/FiftyOne.Pipeline.Core/FlowElements/Pipeline.cs
+++ b/FiftyOne.Pipeline.Core/FlowElements/Pipeline.cs
@@ -180,6 +180,9 @@ namespace FiftyOne.Pipeline.Core.FlowElements
         /// Control field that indicates if the Pipeline will throw an
         /// aggregate exception during processing or suppress it and ignore the
         /// exceptions added to <see cref="IFlowData.Errors"/>.
+        /// When true, exceptions thrown by flow elements are also not logged
+        /// at error level. They are logged at debug level instead and remain
+        /// available through <see cref="IFlowData.Errors"/>.
         /// </summary>
         public bool SuppressProcessExceptions => _suppressProcessExceptions;
 
@@ -416,7 +419,19 @@ namespace FiftyOne.Pipeline.Core.FlowElements
                 {
                     // If an error occurs then store it in the 
                     // FlowData object.
-                    data.AddError(ex, element);
+                    // When exceptions are suppressed, the caller has stated
+                    // that these failures are expected, so do not log at
+                    // error level. The error is still added to
+                    // IFlowData.Errors and is repeated below at debug level
+                    // so the detail is not lost.
+                    data.AddError(ex, element, true, !SuppressProcessExceptions);
+                    if (SuppressProcessExceptions &&
+                        _logger.IsEnabled(LogLevel.Debug))
+                    {
+                        _logger.LogDebug(ex,
+                            $"Suppressed error during processing of " +
+                            $"'{element?.GetType().Name}'.");
+                    }
                 }
             }
 

--- a/Tests/FiftyOne.Pipeline.Core.Tests/FlowElements/ParallelElementsTest.cs
+++ b/Tests/FiftyOne.Pipeline.Core.Tests/FlowElements/ParallelElementsTest.cs
@@ -188,6 +188,8 @@ namespace FiftyOne.Pipeline.Core.Tests.FlowElements
             var element1 = new Mock<IFlowElement>();
             var element2 = new Mock<IFlowElement>();
             var data = new Mock<IFlowData>();
+            _pipeline.Setup(p => p.SuppressProcessExceptions).Returns(false);
+            data.Setup(d => d.Pipeline).Returns(_pipeline.Object);
 
             // Configure element 2 to throw an exception.
             element2.Setup(e => e.Process(It.IsAny<IFlowData>()))
@@ -201,8 +203,8 @@ namespace FiftyOne.Pipeline.Core.Tests.FlowElements
             _parallelElements.Process(data.Object);
 
             // Check that add error was called with the expected exception
-            // and flow element. The mock flow data has no pipeline, so
-            // exceptions are not suppressed and the error is logged.
+            // and flow element. Exceptions are not suppressed, so the error
+            // is flagged for logging.
             data.Verify(d => d.AddError(
                 It.Is<Exception>(ex => ex.Message == "TEST"),
                 element2.Object,

--- a/Tests/FiftyOne.Pipeline.Core.Tests/FlowElements/ParallelElementsTest.cs
+++ b/Tests/FiftyOne.Pipeline.Core.Tests/FlowElements/ParallelElementsTest.cs
@@ -200,11 +200,49 @@ namespace FiftyOne.Pipeline.Core.Tests.FlowElements
             // Start processing
             _parallelElements.Process(data.Object);
 
-            // Check that add error was called with the expected exception 
-            // and flow element.
+            // Check that add error was called with the expected exception
+            // and flow element. The mock flow data has no pipeline, so
+            // exceptions are not suppressed and the error is logged.
             data.Verify(d => d.AddError(
                 It.Is<Exception>(ex => ex.Message == "TEST"),
-                element2.Object),
+                element2.Object,
+                true,
+                true),
+                Times.Once());
+        }
+
+        [TestMethod]
+        /// <summary>
+        /// Check that an exception being thrown by a flow element is not
+        /// flagged for error level logging when the pipeline is suppressing
+        /// process exceptions (issue #280).
+        /// </summary>
+        public void ParallelElements_ExceptionDuringProcessingSuppressed()
+        {
+            var element1 = new Mock<IFlowElement>();
+            var element2 = new Mock<IFlowElement>();
+            var data = new Mock<IFlowData>();
+            _pipeline.Setup(p => p.SuppressProcessExceptions).Returns(true);
+            data.Setup(d => d.Pipeline).Returns(_pipeline.Object);
+
+            // Configure element 2 to throw an exception.
+            element2.Setup(e => e.Process(It.IsAny<IFlowData>()))
+                .Throws(new Exception("TEST"));
+
+            _parallelElements = new ParallelElements(_logger.Object,
+                element1.Object,
+                element2.Object);
+
+            // Start processing
+            _parallelElements.Process(data.Object);
+
+            // Check that add error was called asking for the error not to
+            // be logged.
+            data.Verify(d => d.AddError(
+                It.Is<Exception>(ex => ex.Message == "TEST"),
+                element2.Object,
+                true,
+                false),
                 Times.Once());
         }
 

--- a/Tests/FiftyOne.Pipeline.Core.Tests/FlowElements/PipelineTest.cs
+++ b/Tests/FiftyOne.Pipeline.Core.Tests/FlowElements/PipelineTest.cs
@@ -356,6 +356,8 @@ namespace FiftyOne.Pipeline.Core.Tests.FlowElements
         /// Check that an exception being thrown by a flow element will 
         /// result in the AddError method being called on FlowData and that
         /// the exception is suppressed.
+        /// As exceptions are suppressed, the error must not be flagged for
+        /// error level logging (issue #280).
         /// </summary>
         public void Pipeline_ExceptionDuringProcessingAdd()
         {
@@ -381,7 +383,46 @@ namespace FiftyOne.Pipeline.Core.Tests.FlowElements
             // and flow element.
             data.Verify(d => d.AddError(
                 It.Is<Exception>(ex => ex.Message == "TEST"),
-                element2.Object),
+                element2.Object,
+                true,
+                false),
+                Times.Once());
+        }
+
+        [TestMethod]
+        /// <summary>
+        /// Check that an exception being thrown by a flow element is flagged
+        /// for error level logging when exceptions are not suppressed
+        /// (issue #280).
+        /// </summary>
+        public void Pipeline_ExceptionDuringProcessingLogged()
+        {
+            var element1 = GetMockFlowElement();
+            var element2 = GetMockFlowElement();
+            var data = new Mock<IFlowData>();
+
+            // Configure element 2 to throw an exception.
+            element2.Setup(e => e.Process(It.IsAny<IFlowData>()))
+                .Throws(new Exception("TEST"));
+
+            // Create the pipeline with exceptions not suppressed.
+            var pipeline = CreatePipeline(
+                false,
+                false,
+                element1.Object,
+                element2.Object);
+
+            // Start processing. The mock flow data returns no errors, so no
+            // aggregate exception is thrown here.
+            pipeline.Process(data.Object);
+
+            // Check that add error was called requesting that the error
+            // is logged.
+            data.Verify(d => d.AddError(
+                It.Is<Exception>(ex => ex.Message == "TEST"),
+                element2.Object,
+                true,
+                true),
                 Times.Once());
         }
 

--- a/Tests/FiftyOne.Pipeline.Core.Tests/FlowElements/PipelineTest.cs
+++ b/Tests/FiftyOne.Pipeline.Core.Tests/FlowElements/PipelineTest.cs
@@ -20,6 +20,7 @@
  * such notice(s) shall fulfill the requirements of that article.
  * ********************************************************************* */
 
+using FiftyOne.Common.TestHelpers;
 using FiftyOne.Pipeline.Core.Data;
 using FiftyOne.Pipeline.Core.Exceptions;
 using FiftyOne.Pipeline.Core.FlowElements;
@@ -29,6 +30,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -424,6 +426,63 @@ namespace FiftyOne.Pipeline.Core.Tests.FlowElements
                 true,
                 true),
                 Times.Once());
+        }
+
+        [TestMethod]
+        /// <summary>
+        /// End to end check that a real pipeline and flow data log nothing
+        /// at error level when exceptions are suppressed, and that the error
+        /// is still available through IFlowData.Errors (issue #280).
+        /// </summary>
+        public void Pipeline_ExceptionDuringProcessing_Suppressed_NotLoggedAsError()
+        {
+            var loggerFactory = new TestLoggerFactory();
+            var element = GetMockFlowElement();
+            element.Setup(e => e.Process(It.IsAny<IFlowData>()))
+                .Throws(new Exception("TEST"));
+
+            using (var pipeline = new PipelineBuilder(loggerFactory)
+                .AddFlowElement(element.Object)
+                .SetSuppressProcessExceptions(true)
+                .Build())
+            using (var data = pipeline.CreateFlowData())
+            {
+                data.Process();
+
+                Assert.HasCount(1, data.Errors,
+                    "The error should still be recorded in FlowData.Errors.");
+            }
+
+            // Nothing must have been logged at error level.
+            loggerFactory.AssertMaxErrors(0);
+        }
+
+        [TestMethod]
+        /// <summary>
+        /// End to end check that a real pipeline and flow data do log at
+        /// error level when exceptions are not suppressed (issue #280).
+        /// </summary>
+        public void Pipeline_ExceptionDuringProcessing_NotSuppressed_LoggedAsError()
+        {
+            var loggerFactory = new TestLoggerFactory();
+            var element = GetMockFlowElement();
+            element.Setup(e => e.Process(It.IsAny<IFlowData>()))
+                .Throws(new Exception("TEST"));
+
+            using (var pipeline = new PipelineBuilder(loggerFactory)
+                .AddFlowElement(element.Object)
+                .SetSuppressProcessExceptions(false)
+                .Build())
+            using (var data = pipeline.CreateFlowData())
+            {
+                Assert.ThrowsExactly<AggregateException>(() => data.Process());
+            }
+
+            var errorEntries = loggerFactory.Loggers
+                .SelectMany(l => l.ErrorEntries)
+                .ToList();
+            Assert.HasCount(1, errorEntries,
+                "The error should have been logged at error level.");
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #280. When SuppressProcessExceptions is true, Pipeline.Process and ParallelElements.ProcessInternal pass shouldLog: !SuppressProcessExceptions to IFlowData.AddError, so exceptions that escape an element's Process are no longer logged at Error level. They are logged at Debug instead and stay available via IFlowData.Errors. Scope: errors an element records itself by calling AddError are unaffected — this is documented on IPipeline.SuppressProcessExceptions. No public API change. Behavioural change worth a release note: operators alerting on those Error entries will go quiet once suppression is enabled. Tests cover both directions, including end-to-end assertions on a real pipeline via TestLoggerFactory. FiftyOne.Pipeline.Core.Tests 277/277 green on net8.0.