### PR TITLE
Tolerate missing source properties in the translation engine base

### DIFF
--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.Translation.Tests/MissingSourcePropertyTests.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.Translation.Tests/MissingSourcePropertyTests.cs
@@ -1,0 +1,263 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+using FiftyOne.Pipeline.Core.Data;
+using FiftyOne.Pipeline.Core.FlowElements;
+using FiftyOne.Pipeline.Engines;
+using FiftyOne.Pipeline.Engines.Data;
+using FiftyOne.Pipeline.Translation.Data;
+using FiftyOne.Pipeline.Translation.FlowElements;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace FiftyOne.Pipeline.Translation.Tests;
+
+/// <summary>
+/// Tests for the behavior of the translation engine when the source
+/// property cannot be read. Aspect data (for example a cloud engine's data
+/// when the resource key does not include the property, or when the cloud
+/// request failed) throws <see cref="PropertyMissingException"/> from its
+/// indexer where plain element data returns null; both must result in a
+/// no-value placeholder rather than a per-request exception.
+/// </summary>
+[TestClass]
+public class MissingSourcePropertyTests
+{
+    private ILoggerFactory _loggerFactory = LoggerFactory.Create(b => { });
+
+    /// <summary>
+    /// A source whose indexer throws PropertyMissingException for a missing
+    /// property (as aspect data does) must not make the engine throw. The
+    /// destination gets a no-value placeholder. The pipeline is built
+    /// WITHOUT suppressed process exceptions so any escaping exception
+    /// fails the test.
+    /// </summary>
+    [TestMethod]
+    public void SourceThrowsPropertyMissing_ProducesNoValuePlaceholder()
+    {
+        using var flowData = Setup();
+
+        flowData.AddEvidence("header.accept-language", "fr_FR");
+        flowData.Process();
+
+        var result = flowData.Get<ITranslationData>();
+        var translation = result["AnimalTranslated"];
+
+        Assert.IsNotNull(translation);
+        Assert.IsInstanceOfType(translation, typeof(IAspectPropertyValue<string>));
+        var aspectValue = translation as IAspectPropertyValue<string>;
+        Assert.IsFalse(aspectValue.HasValue);
+        StringAssert.Contains(aspectValue.NoValueMessage, "could not be found");
+    }
+
+    /// <summary>
+    /// When the translation declares the value type readers of the
+    /// destination expect, the no-value placeholder must be of that type so
+    /// typed reads of the destination do not fail with an invalid cast.
+    /// </summary>
+    [TestMethod]
+    public void SourceThrowsPropertyMissing_TypedPlaceholder()
+    {
+        using var flowData = Setup(typedDestination: true);
+
+        flowData.AddEvidence("header.accept-language", "fr_FR");
+        flowData.Process();
+
+        var result = flowData.Get<ITranslationData>();
+        var translation = result["AnimalTranslated"];
+
+        Assert.IsNotNull(translation);
+        Assert.IsInstanceOfType(
+            translation,
+            typeof(IAspectPropertyValue<IReadOnlyList<IWeightedValue<string>>>));
+        var aspectValue = translation
+            as IAspectPropertyValue<IReadOnlyList<IWeightedValue<string>>>;
+        Assert.IsFalse(aspectValue.HasValue);
+        StringAssert.Contains(aspectValue.NoValueMessage, "could not be found");
+    }
+
+    /// <summary>
+    /// A source property that is absent (null) also gets the typed
+    /// placeholder when a destination value type is declared.
+    /// </summary>
+    [TestMethod]
+    public void SourceAbsent_TypedPlaceholder()
+    {
+        using var flowData = Setup(
+            typedDestination: true,
+            sourceThrows: false);
+
+        flowData.AddEvidence("header.accept-language", "fr_FR");
+        flowData.Process();
+
+        var result = flowData.Get<ITranslationData>();
+        var translation = result["AnimalTranslated"];
+
+        Assert.IsNotNull(translation);
+        Assert.IsInstanceOfType(
+            translation,
+            typeof(IAspectPropertyValue<IReadOnlyList<IWeightedValue<string>>>));
+        var aspectValue = translation
+            as IAspectPropertyValue<IReadOnlyList<IWeightedValue<string>>>;
+        Assert.IsFalse(aspectValue.HasValue);
+        StringAssert.Contains(aspectValue.NoValueMessage, "could not be found");
+    }
+
+    /// <summary>
+    /// Build a pipeline of a source element (throwing or returning null for
+    /// every property read) followed by a translation engine, and return a
+    /// flow data ready to process. Process exceptions are NOT suppressed.
+    /// </summary>
+    private IFlowData Setup(
+        bool typedDestination = false,
+        bool sourceThrows = true)
+    {
+        var translations = new Dictionary<string, string>()
+        {
+            { "cat", "chat" },
+            { "dog", "chien" }
+        };
+        var file = CreateFile("animals.fr_FR.yml", translations);
+
+        var builder = new TranslationEngineBuilder(_loggerFactory)
+            .SetSourceElementDataKey("throwingsource")
+            .AddSource(file.File.FullName);
+        if (typedDestination)
+        {
+            builder.AddTranslation<IReadOnlyList<IWeightedValue<string>>>(
+                "Animal", "AnimalTranslated");
+        }
+        else
+        {
+            builder.AddTranslation("Animal", "AnimalTranslated");
+        }
+        var engine = builder.Build();
+
+        var pipeline = new PipelineBuilder(_loggerFactory)
+            .AddFlowElement(new ThrowingSourceElement(
+                _loggerFactory.CreateLogger<ThrowingSourceElement>(),
+                sourceThrows))
+            .AddFlowElement(engine)
+            .Build();
+
+        return pipeline.CreateFlowData();
+    }
+
+    private TempFile CreateFile(
+        string name,
+        IReadOnlyDictionary<string, string> translations)
+    {
+        var path = Path.Combine(Path.GetTempPath(), name);
+        using (var writer = new StreamWriter(path))
+        {
+            foreach (var translation in translations)
+            {
+                writer.WriteLine($"{translation.Key}: {translation.Value}");
+            }
+        }
+        return new TempFile(new FileInfo(path));
+    }
+
+    private class TempFile : IDisposable
+    {
+        public TempFile(FileInfo file)
+        {
+            File = file;
+        }
+
+        public FileInfo File { get; }
+
+        public void Dispose()
+        {
+            File.Delete();
+        }
+    }
+
+    /// <summary>
+    /// Element data whose indexer throws PropertyMissingException for every
+    /// read, mirroring an aspect data whose property is not available.
+    /// When configured not to throw it returns null instead.
+    /// </summary>
+    private class ThrowingSourceData : ElementDataBase
+    {
+        private readonly bool _throws;
+
+        public ThrowingSourceData(IPipeline pipeline, bool throws)
+            : base(null, pipeline)
+        {
+            _throws = throws;
+        }
+
+        public override object this[string key]
+        {
+            get
+            {
+                if (_throws)
+                {
+                    throw new PropertyMissingException(
+                        $"Property '{key}' not found in data for element " +
+                        $"'throwingsource'.");
+                }
+                return null;
+            }
+            set { base[key] = value; }
+        }
+    }
+
+    /// <summary>
+    /// Element whose data throws (or returns null) for every property read.
+    /// </summary>
+    private class ThrowingSourceElement
+        : FlowElementBase<ThrowingSourceData, ElementPropertyMetaData>
+    {
+        private readonly bool _throws;
+
+        public ThrowingSourceElement(
+            ILogger<FlowElementBase<ThrowingSourceData, ElementPropertyMetaData>> logger,
+            bool throws)
+            : base(logger)
+        {
+            _throws = throws;
+        }
+
+        public override string ElementDataKey => "throwingsource";
+
+        public override IEvidenceKeyFilter EvidenceKeyFilter =>
+            new EvidenceKeyFilterWhitelist(new List<string>());
+
+        public override IList<ElementPropertyMetaData> Properties =>
+            new List<ElementPropertyMetaData>();
+
+        protected override void ProcessInternal(IFlowData data)
+        {
+            data.GetOrAdd(
+                ElementDataKey,
+                p => new ThrowingSourceData(p, _throws));
+        }
+
+        protected override void ManagedResourcesCleanup() { }
+
+        protected override void UnmanagedResourcesCleanup() { }
+    }
+}

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.Translation/Data/TranslationProperty.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.Translation/Data/TranslationProperty.cs
@@ -1,4 +1,4 @@
-﻿/* *********************************************************************
+/* *********************************************************************
  * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
  * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
  * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
@@ -20,10 +20,13 @@
  * such notice(s) shall fulfill the requirements of that article.
  * ********************************************************************* */
 
+using FiftyOne.Pipeline.Engines.Data;
+using System;
+
 namespace FiftyOne.Pipeline.Translation.Data
 {
     /// <summary>
-    /// Defines a translation from one property to another. 
+    /// Defines a translation from one property to another.
     /// </summary>
     public class TranslationProperty
     {
@@ -33,9 +36,58 @@ namespace FiftyOne.Pipeline.Translation.Data
         /// <param name="source"></param>
         /// <param name="destination"></param>
         public TranslationProperty(string source, string destination)
+            : this(
+                  source,
+                  destination,
+                  message => new AspectPropertyValue<string>()
+                  {
+                      NoValueMessage = message,
+                  })
+        {
+        }
+
+        private TranslationProperty(
+            string source,
+            string destination,
+            Func<string, IAspectPropertyValue> createNoValuePlaceholder)
         {
             SourceProperty = source;
             DestinationProperty = destination;
+            CreateNoValuePlaceholder = createNoValuePlaceholder;
+        }
+
+        /// <summary>
+        /// Creates a translation whose no-value placeholder is typed for
+        /// the readers of the destination property.
+        /// </summary>
+        /// <typeparam name="TDestination">
+        /// The value type readers of the destination property expect,
+        /// i.e. the T of the
+        /// <see cref="IAspectPropertyValue{T}"/> they read it as. When the
+        /// source property has no value, the placeholder stored against
+        /// the destination is created with this type so typed reads of the
+        /// destination do not fail with an invalid cast.
+        /// </typeparam>
+        /// <param name="source">
+        /// Source property name on the source element data.
+        /// </param>
+        /// <param name="destination">
+        /// Destination property name on translation engine data.
+        /// </param>
+        /// <returns>
+        /// A new <see cref="TranslationProperty"/>.
+        /// </returns>
+        public static TranslationProperty Create<TDestination>(
+            string source,
+            string destination)
+        {
+            return new TranslationProperty(
+                source,
+                destination,
+                message => new AspectPropertyValue<TDestination>()
+                {
+                    NoValueMessage = message,
+                });
         }
 
         /// <summary>
@@ -47,5 +99,13 @@ namespace FiftyOne.Pipeline.Translation.Data
         /// Destination property name on translation engine data.
         /// </summary>
         public string DestinationProperty { get; set; }
+
+        /// <summary>
+        /// Creates the no-value placeholder stored against the destination
+        /// property when the source property has no value. The supplied
+        /// string is the placeholder's no-value message.
+        /// </summary>
+        public Func<string, IAspectPropertyValue> CreateNoValuePlaceholder
+        { get; }
     }
 }

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.Translation/FiftyOne.Pipeline.Translation.xml
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.Translation/FiftyOne.Pipeline.Translation.xml
@@ -158,7 +158,7 @@
         </member>
         <member name="T:FiftyOne.Pipeline.Translation.Data.TranslationProperty">
             <summary>
-            Defines a translation from one property to another. 
+            Defines a translation from one property to another.
             </summary>
         </member>
         <member name="M:FiftyOne.Pipeline.Translation.Data.TranslationProperty.#ctor(System.String,System.String)">
@@ -168,6 +168,29 @@
             <param name="source"></param>
             <param name="destination"></param>
         </member>
+        <member name="M:FiftyOne.Pipeline.Translation.Data.TranslationProperty.Create``1(System.String,System.String)">
+            <summary>
+            Creates a translation whose no-value placeholder is typed for
+            the readers of the destination property.
+            </summary>
+            <typeparam name="TDestination">
+            The value type readers of the destination property expect,
+            i.e. the T of the
+            <see cref="T:FiftyOne.Pipeline.Engines.Data.IAspectPropertyValue`1"/> they read it as. When the
+            source property has no value, the placeholder stored against
+            the destination is created with this type so typed reads of the
+            destination do not fail with an invalid cast.
+            </typeparam>
+            <param name="source">
+            Source property name on the source element data.
+            </param>
+            <param name="destination">
+            Destination property name on translation engine data.
+            </param>
+            <returns>
+            A new <see cref="T:FiftyOne.Pipeline.Translation.Data.TranslationProperty"/>.
+            </returns>
+        </member>
         <member name="P:FiftyOne.Pipeline.Translation.Data.TranslationProperty.SourceProperty">
             <summary>
             Source property name on the source element data.
@@ -176,6 +199,13 @@
         <member name="P:FiftyOne.Pipeline.Translation.Data.TranslationProperty.DestinationProperty">
             <summary>
             Destination property name on translation engine data.
+            </summary>
+        </member>
+        <member name="P:FiftyOne.Pipeline.Translation.Data.TranslationProperty.CreateNoValuePlaceholder">
+            <summary>
+            Creates the no-value placeholder stored against the destination
+            property when the source property has no value. The supplied
+            string is the placeholder's no-value message.
             </summary>
         </member>
         <member name="T:FiftyOne.Pipeline.Translation.Data.Translator">
@@ -468,7 +498,14 @@
         </member>
         <member name="M:FiftyOne.Pipeline.Translation.FlowElements.TranslationEngineBase`1.TryGetSourceValue(FiftyOne.Pipeline.Core.Data.IElementData,System.String,System.Object@)">
             <summary>
-            Gets the source value from the sourceData
+            Gets the source value from the sourceData.
+            The value is read through <see cref="M:FiftyOne.Pipeline.Core.Data.IData.AsDictionary"/>
+            rather than the indexer because a missing property must report
+            false, not throw: aspect data (for example a cloud engine's
+            data when the resource key does not include the property, or
+            when the cloud request failed) throws from its indexer for a
+            missing property, while its AsDictionary waits for any lazy
+            loading and then supports a non-throwing lookup.
             </summary>
             <param name="sourceData"></param>
             <param name="sourceProperty"></param>
@@ -591,6 +628,27 @@
             Add translated property. This defines a translation from one property
             to another.
             </summary>
+            <param name="source">
+            The key for the source property to translate.
+            </param>
+            <param name="destination">
+            The key to store the translated value under on the translation engine data.
+            </param>
+            <returns>
+            This builder.
+            </returns>
+        </member>
+        <member name="M:FiftyOne.Pipeline.Translation.FlowElements.TranslationEngineBuilder.AddTranslation``1(System.String,System.String)">
+            <summary>
+            Add translated property. This defines a translation from one property
+            to another.
+            </summary>
+            <typeparam name="TDestination">
+            The value type readers of the destination property expect. When
+            the source property has no value, the no-value placeholder stored
+            against the destination is created with this type so typed reads
+            of the destination do not fail with an invalid cast.
+            </typeparam>
             <param name="source">
             The key for the source property to translate.
             </param>

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.Translation/FlowElements/TranslationEngineBase.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.Translation/FlowElements/TranslationEngineBase.cs
@@ -375,7 +375,14 @@ namespace FiftyOne.Pipeline.Translation.FlowElements
         }
 
         /// <summary>
-        /// Gets the source value from the sourceData
+        /// Gets the source value from the sourceData.
+        /// The value is read through <see cref="IData.AsDictionary"/>
+        /// rather than the indexer because a missing property must report
+        /// false, not throw: aspect data (for example a cloud engine's
+        /// data when the resource key does not include the property, or
+        /// when the cloud request failed) throws from its indexer for a
+        /// missing property, while its AsDictionary waits for any lazy
+        /// loading and then supports a non-throwing lookup.
         /// </summary>
         /// <param name="sourceData"></param>
         /// <param name="sourceProperty"></param>
@@ -394,8 +401,9 @@ namespace FiftyOne.Pipeline.Translation.FlowElements
                 return false;
             }
 
-            sourceValue = sourceData[sourceProperty];
-            return sourceValue != null;
+            return sourceData.AsDictionary()
+                    .TryGetValue(sourceProperty, out sourceValue) &&
+                sourceValue != null;
         }
 
         /// <summary>
@@ -419,14 +427,11 @@ namespace FiftyOne.Pipeline.Translation.FlowElements
                    property.SourceProperty,
                    out object sourceValue) == false)
                 {
-                    // Here there is no way to know what type the source property
-                    // is, so we don't have to match it. Meaning we can use an
-                    // AspectPropertyValue.
-                    var value = new AspectPropertyValue<string>();
-                    value.NoValueMessage = $"The source property " +
-                        $"'{property.SourceProperty}' could not be found in " +
-                        $"the source data.";
-                    translationData[property.DestinationProperty] = value;
+                    translationData[property.DestinationProperty] =
+                        property.CreateNoValuePlaceholder(
+                            $"The source property " +
+                            $"'{property.SourceProperty}' could not be " +
+                            $"found in the source data.");
                 }
                 else
                 {

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.Translation/FlowElements/TranslationEngineBuilder.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.Translation/FlowElements/TranslationEngineBuilder.cs
@@ -168,6 +168,39 @@ namespace FiftyOne.Pipeline.Translation.FlowElements
         }
 
         /// <summary>
+        /// Add translated property. This defines a translation from one property
+        /// to another.
+        /// </summary>
+        /// <typeparam name="TDestination">
+        /// The value type readers of the destination property expect. When
+        /// the source property has no value, the no-value placeholder stored
+        /// against the destination is created with this type so typed reads
+        /// of the destination do not fail with an invalid cast.
+        /// </typeparam>
+        /// <param name="source">
+        /// The key for the source property to translate.
+        /// </param>
+        /// <param name="destination">
+        /// The key to store the translated value under on the translation engine data.
+        /// </param>
+        /// <returns>
+        /// This builder.
+        /// </returns>
+        public TranslationEngineBuilder AddTranslation<TDestination>(
+            string source,
+            string destination)
+        {
+            if (source == null || destination == null)
+            {
+                throw new ArgumentNullException();
+            }
+
+            _translationProperties.Add(
+                TranslationProperty.Create<TDestination>(source, destination));
+            return this;
+        }
+
+        /// <summary>
         /// Add a source file containing translations. These follow the naming
         /// convention 'abc.en_GB.yml' where 'abc' can be any idenitifier,
         /// 'en_GB' is the locale code, and 'yml' is the file extension. The


### PR DESCRIPTION
Contributes to 51Degrees/Website#900 (exception noise investigated under 51Degrees/Website#885).

### The problem

TranslationEngineBase reads each source property through the element data indexer. Plain element data returns null for a missing property but aspect data throws PropertyMissingException, which is what a cloud engine's data contains when the resource key does not include the property or the cloud request failed. The exception escapes as a per-request error, 428 occurrences in 30 days on the website's IpTester, ContactUs, WhatIsMyIp and Me pages. Separately, the no-value placeholder is always AspectPropertyValue&lt;string&gt;, so any reader expecting the destination's real type gets InvalidCastException.

### The fix

The source read goes through AsDictionary().TryGetValue, the framework's non-throwing lookup that also waits for lazy loading on aspect data, so a missing property reaches the existing no-value path on every data implementation. TranslationProperty now carries a placeholder factory captured at the declaration site, via TranslationProperty.Create&lt;TDestination&gt; and a generic AddTranslation&lt;TDestination&gt; builder overload, so placeholders are created with the type readers expect without reflection. Undeclared translations keep the string placeholder.

### Testing

New MissingSourcePropertyTests drive the engine from a source whose indexer throws PropertyMissingException, on an unsuppressed pipeline so any escape fails the test. Translation suite 44 passed, 0 failed.

### Rollout

Additive API only, existing callers unaffected. Consumers that relied on the throw now inspect the destination's no-value state, with the accurate missing reason still available on the source property. Follow-up in ip-intelligence-dotnet declares the weighted list types for the country translations once this package ships.
