### PR TITLE
Tolerate missing set-headers data in the web integrations

### DIFF
--- a/Web Integration/FiftyOne.Pipeline.Web.Framework/Providers/SetHeadersProvider.cs
+++ b/Web Integration/FiftyOne.Pipeline.Web.Framework/Providers/SetHeadersProvider.cs
@@ -21,6 +21,7 @@
  * ********************************************************************* */
 
 using FiftyOne.Pipeline.Core.Data;
+using FiftyOne.Pipeline.Engines.FiftyOne.Data;
 using FiftyOne.Pipeline.Engines.FiftyOne.FlowElements;
 using System;
 using System.Collections.Generic;
@@ -82,7 +83,11 @@ namespace FiftyOne.Pipeline.Web.Framework.Providers
 
         /// <summary>
         /// Set the HTTP headers in the response based
-        /// on values from the <see cref="SetHeadersElement"/>
+        /// on values from the <see cref="SetHeadersElement"/>.
+        /// If the flow data has no data for the element (its processing can
+        /// fail before the data is added, for example when the cloud
+        /// service could not be reached, with the pipeline configured to
+        /// suppress process exceptions), then no headers are set.
         /// </summary>
         /// <param name="flowData">
         /// The flow data containing the information about the headers to set.
@@ -95,11 +100,13 @@ namespace FiftyOne.Pipeline.Web.Framework.Providers
             if (flowData == null) throw new ArgumentNullException(nameof(flowData));
             if (context == null) throw new ArgumentNullException(nameof(context));
 
-            if (_setHeadersElement != null)
+            if (_setHeadersElement != null &&
+                flowData.TryGetValue(
+                    _setHeadersElement.ElementDataKeyTyped,
+                    out var setHeadersData) &&
+                setHeadersData.ResponseHeaderDictionary != null)
             {
-                var headersToSet = flowData
-                    .GetFromElement(_setHeadersElement).ResponseHeaderDictionary;
-                SetHeaders(context, headersToSet);
+                SetHeaders(context, setHeadersData.ResponseHeaderDictionary);
             }
         }
 

--- a/Web Integration/FiftyOne.Pipeline.Web/Services/SetHeadersService.cs
+++ b/Web Integration/FiftyOne.Pipeline.Web/Services/SetHeadersService.cs
@@ -22,6 +22,7 @@
 
 using FiftyOne.Pipeline.Core.Data;
 using FiftyOne.Pipeline.Core.FlowElements;
+using FiftyOne.Pipeline.Engines.FiftyOne.Data;
 using FiftyOne.Pipeline.Engines.FiftyOne.FlowElements;
 using FiftyOne.Pipeline.Web.Shared;
 using Microsoft.AspNetCore.Http;
@@ -75,10 +76,16 @@ namespace FiftyOne.Pipeline.Web.Services
         }
 
         /// <summary>
-        /// Set the HTTP headers in the response using values from 
+        /// Set the HTTP headers in the response using values from
         /// the supplied flow data.
         /// If the supplied headers already have values in the response
         /// then they will be amended rather than replaced.
+        /// If the pipeline has no <see cref="ISetHeadersElement"/>, or the
+        /// flow data has no data for it (its processing can fail before the
+        /// data is added, for example when the cloud service could not be
+        /// reached, with the pipeline configured to suppress process
+        /// exceptions), then no headers are set. The upstream failure is
+        /// already reported by the pipeline's own error handling.
         /// </summary>
         /// <param name="context">
         /// The <see cref="HttpContext"/> to set the response headers in
@@ -86,15 +93,25 @@ namespace FiftyOne.Pipeline.Web.Services
         /// <param name="flowData">
         /// The flow data containing the headers to set.
         /// </param>
-        public static void SetHeaders(HttpContext context, 
+        public static void SetHeaders(HttpContext context,
             IFlowData flowData)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
             if (flowData == null) throw new ArgumentNullException(nameof(flowData));
 
             var element = flowData.Pipeline.GetElement<ISetHeadersElement>();
-            foreach (var header in flowData.GetFromElement(element)
-                .ResponseHeaderDictionary)
+            if (element == null)
+            {
+                return;
+            }
+            if (flowData.TryGetValue(
+                    element.ElementDataKeyTyped,
+                    out var setHeadersData) == false ||
+                setHeadersData.ResponseHeaderDictionary == null)
+            {
+                return;
+            }
+            foreach (var header in setHeadersData.ResponseHeaderDictionary)
             {
                 context.Response.Headers.Append(header.Key, header.Value);
             }

--- a/Web Integration/Tests/FiftyOne.Pipeline.Web.Tests/SetHeadersServiceTests.cs
+++ b/Web Integration/Tests/FiftyOne.Pipeline.Web.Tests/SetHeadersServiceTests.cs
@@ -1,0 +1,147 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+using FiftyOne.Pipeline.Core.Data;
+using FiftyOne.Pipeline.Core.FlowElements;
+using FiftyOne.Pipeline.Core.TypedMap;
+using FiftyOne.Pipeline.Engines.FiftyOne.Data;
+using FiftyOne.Pipeline.Engines.FiftyOne.FlowElements;
+using FiftyOne.Pipeline.Web.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System.Collections.Generic;
+
+namespace FiftyOne.Pipeline.Web.Tests
+{
+    /// <summary>
+    /// Tests for <see cref="SetHeaderService"/>. The service runs on every
+    /// request from the middleware, so it must tolerate a flow data with no
+    /// set-headers entry: the element's processing can fail before its data
+    /// is added (for example when the cloud service could not be reached,
+    /// with the pipeline configured to suppress process exceptions).
+    /// </summary>
+    [TestClass]
+    public class SetHeadersServiceTests
+    {
+        private Mock<IPipeline> _pipeline;
+        private Mock<IFlowData> _flowData;
+        private Mock<ISetHeadersElement> _element;
+        private HttpContext _context;
+
+        [TestInitialize]
+        public void SetUp()
+        {
+            _pipeline = new Mock<IPipeline>();
+            _flowData = new Mock<IFlowData>();
+            _flowData.SetupGet(f => f.Pipeline).Returns(_pipeline.Object);
+            _element = new Mock<ISetHeadersElement>();
+            _element.SetupGet(e => e.ElementDataKey)
+                .Returns(SetHeadersElement.DEFAULT_ELEMENT_DATA_KEY);
+            _context = new DefaultHttpContext();
+        }
+
+        /// <summary>
+        /// The happy path: headers from the set-headers data are appended
+        /// to the response.
+        /// </summary>
+        [TestMethod]
+        public void SetHeaders_AppendsHeaders()
+        {
+            var setHeadersData = new Mock<ISetHeadersData>();
+            setHeadersData.SetupGet(d => d.ResponseHeaderDictionary)
+                .Returns(new Dictionary<string, string>()
+                {
+                    { "Accept-CH", "Sec-CH-UA-Model" }
+                });
+            SetupPipeline(setHeadersData.Object);
+
+            SetHeaderService.SetHeaders(_context, _flowData.Object);
+
+            Assert.AreEqual(
+                "Sec-CH-UA-Model",
+                (string)_context.Response.Headers["Accept-CH"]);
+        }
+
+        /// <summary>
+        /// A pipeline without a set headers element results in no headers
+        /// and no exception.
+        /// </summary>
+        [TestMethod]
+        public void SetHeaders_NoElement_DoesNotThrow()
+        {
+            _pipeline.Setup(p => p.GetElement<ISetHeadersElement>())
+                .Returns((ISetHeadersElement)null);
+
+            SetHeaderService.SetHeaders(_context, _flowData.Object);
+
+            Assert.AreEqual(0, _context.Response.Headers.Count);
+        }
+
+        /// <summary>
+        /// A flow data without set-headers data (the element's processing
+        /// failed before the data was added) results in no headers and no
+        /// exception.
+        /// </summary>
+        [TestMethod]
+        public void SetHeaders_NoElementData_DoesNotThrow()
+        {
+            SetupPipeline(null);
+
+            SetHeaderService.SetHeaders(_context, _flowData.Object);
+
+            Assert.AreEqual(0, _context.Response.Headers.Count);
+        }
+
+        /// <summary>
+        /// Set-headers data whose dictionary was never populated (the
+        /// element's processing failed after the data was added) results in
+        /// no headers and no exception.
+        /// </summary>
+        [TestMethod]
+        public void SetHeaders_NullDictionary_DoesNotThrow()
+        {
+            var setHeadersData = new Mock<ISetHeadersData>();
+            setHeadersData.SetupGet(d => d.ResponseHeaderDictionary)
+                .Returns((IReadOnlyDictionary<string, string>)null);
+            SetupPipeline(setHeadersData.Object);
+
+            SetHeaderService.SetHeaders(_context, _flowData.Object);
+
+            Assert.AreEqual(0, _context.Response.Headers.Count);
+        }
+
+        /// <summary>
+        /// Configure the pipeline to contain the set headers element and the
+        /// flow data to hold the given data for it (no data when null).
+        /// </summary>
+        private void SetupPipeline(ISetHeadersData setHeadersData)
+        {
+            _pipeline.Setup(p => p.GetElement<ISetHeadersElement>())
+                .Returns(_element.Object);
+            var outData = setHeadersData;
+            _flowData.Setup(f => f.TryGetValue(
+                    It.IsAny<ITypedKey<ISetHeadersData>>(), out outData))
+                .Returns(setHeadersData != null);
+        }
+    }
+}


### PR DESCRIPTION
Contributes to 51Degrees/Website#902 (exception noise investigated under 51Degrees/Website#885).

### The problem

FiftyOneMiddleware calls SetHeaderService.SetHeaders on every request, and the service reads the set-headers element data unconditionally. SetHeadersElement's processing can fail before its element data is added, because it populates its configuration by walking every element's Properties and cloud engines load that metadata lazily from the cloud. On an instance that cannot reach cloud.51degrees.com the getter throws, the element's process fails under SuppressProcessExceptions, no set-headers data is added, and the middleware read throws KeyNotFoundException on every request, outside the pipeline's suppression. Around 800 occurrences in 30 days on the 51degrees.com website, in both observed variants (empty key map when the cloud request engine also failed before adding its data, and a cloud-response-only map when it did not).

Answering the issue's other question, SetHeadersElement IS present in the website pipeline. FiftyOneStartup.AddSetHeadersElement appends it automatically to any pipeline built through AddFiftyOne, so Client Hints headers are set correctly in normal operation and there is no ongoing SEO impact.

### The fix

Try-get semantics throughout the service read: no ISetHeadersElement in the pipeline, no set-headers entry in the flow data, or a null response header dictionary each return quietly instead of throwing. The lookup uses the element's cached ElementDataKeyTyped, the same key instance GetFromElement used, so the guarded path allocates nothing new per request. No new logging on the missing path, the upstream failure is already recorded by the pipeline's own error handling and an hour-long outage window should not trade one noise source for another. The ASP.NET Framework SetHeadersProvider had the same unguarded read and gets the same treatment.

### Testing

New SetHeadersServiceTests cover the happy path (headers appended) and all three missing shapes (no element, no data, null dictionary), each asserting no throw and no headers. Web tests 43 passed, 0 failed. The Framework project builds clean via MSBuild (it does not build via dotnet build, a pre-existing restore limitation, so no Framework test run).

### Rollout

Only the code path that currently throws changes, requests whose pipeline succeeded still get the same headers. Fail-open is correct here, Client Hints headers are an optimization and their absence on a failed-pipeline request is the only sensible output. Follow-up candidate, not included: reorder SetHeadersElement.ProcessInternal to GetOrAdd its element data before populating configuration so the data exists even when config population fails.
