### PR TITLE
Do not throw from Pipeline.Process when all errors are non-throwing

### DIFF
--- a/FiftyOne.Pipeline.Core/FlowElements/Pipeline.cs
+++ b/FiftyOne.Pipeline.Core/FlowElements/Pipeline.cs
@@ -396,11 +396,14 @@ namespace FiftyOne.Pipeline.Core.FlowElements
                 }
             }
 
-            // If any errors have occurred and exceptions are not
-            // suppressed, then throw an aggregate exception.
+            // If any throwing errors have occurred and exceptions are not
+            // suppressed, then throw an aggregate exception. Errors recorded
+            // with ShouldThrow false (e.g. a cloud engine noting that it did
+            // not process because the cloud request failed) are diagnostic
+            // only and must not surface as an exception of their own.
             if (data.Errors != null &&
-                data.Errors.Count > 0 &&
-                SuppressProcessExceptions == false)
+                SuppressProcessExceptions == false &&
+                data.Errors.Any(e => e.ShouldThrow))
             {
                 throw new AggregateException(data.Errors
                     .Where(e => e.ShouldThrow == true)

--- a/Tests/FiftyOne.Pipeline.Core.Tests/FlowElements/PipelineTest.cs
+++ b/Tests/FiftyOne.Pipeline.Core.Tests/FlowElements/PipelineTest.cs
@@ -294,7 +294,87 @@ namespace FiftyOne.Pipeline.Core.Tests.FlowElements
 
         [TestMethod]
         /// <summary>
-        /// Check that an exception being thrown by a flow element will 
+        /// Check that errors recorded with ShouldThrow false (e.g. a cloud
+        /// engine noting that it did not process because the cloud request
+        /// failed) do not cause the Process method to throw, even when
+        /// process exceptions are not suppressed.
+        /// </summary>
+        public void Pipeline_NonThrowingErrorsOnlyDontThrow()
+        {
+            var element1 = GetMockFlowElement();
+            var errors = new List<IFlowError>() {
+                new FlowError(
+                    new Exception("TEST"),
+                    element1.Object,
+                    shouldThrow: false)
+            };
+            var data = new Mock<IFlowData>();
+
+            // Configure the flow data to return errors.
+            data.SetupGet(d => d.Errors).Returns(errors);
+
+            // Create the pipeline without suppressing process exceptions.
+            var pipeline = CreatePipeline(
+                false,
+                false,
+                element1.Object);
+
+            // Start processing. No exception is expected because the only
+            // recorded error is non-throwing.
+            pipeline.Process(data.Object);
+        }
+
+        [TestMethod]
+        /// <summary>
+        /// Check that when throwing and non-throwing errors are mixed, only
+        /// the throwing errors appear in the aggregate exception.
+        /// </summary>
+        public void Pipeline_MixedErrorsThrowOnlyThrowing()
+        {
+            var element1 = GetMockFlowElement();
+            var errors = new List<IFlowError>() {
+                new FlowError(
+                    new Exception("QUIET"),
+                    element1.Object,
+                    shouldThrow: false),
+                new FlowError(new Exception("LOUD"), element1.Object)
+            };
+            var data = new Mock<IFlowData>();
+
+            // Configure the flow data to return errors.
+            data.SetupGet(d => d.Errors).Returns(errors);
+
+            // Create the pipeline without suppressing process exceptions.
+            var pipeline = CreatePipeline(
+                false,
+                false,
+                element1.Object);
+
+            // Start processing.
+            Exception exception = null;
+            try
+            {
+                pipeline.Process(data.Object);
+            }
+            catch (Exception e)
+            {
+                exception = e;
+            }
+
+            // Check that only the throwing error is in the aggregate.
+            Assert.IsNotNull(exception);
+            Assert.IsInstanceOfType(exception, typeof(AggregateException));
+            Assert.HasCount(
+                1,
+                ((AggregateException)exception).InnerExceptions);
+            Assert.AreEqual(
+                "LOUD",
+                ((AggregateException)exception).InnerExceptions[0].Message);
+        }
+
+        [TestMethod]
+        /// <summary>
+        /// Check that an exception being thrown by a flow element will
         /// result in the AddError method being called on FlowData and that
         /// the exception is suppressed.
         /// </summary>


### PR DESCRIPTION
Surfaced while testing the IPI cloud engine's failed-request handling for 51Degrees/Website#901 (part of the 51Degrees/Website#885 exception noise work).

### The problem

Pipeline.Process throws an AggregateException whenever the flow data holds any errors and process exceptions are not suppressed, but the aggregate's inner exceptions are filtered to errors with ShouldThrow true. An error recorded with AddError(shouldThrow: false), such as CloudAspectEngineBase noting that it did not process because the cloud request failed, therefore surfaces as "One or more errors occurred." with zero inner exceptions and nothing to diagnose. That contradicts the AddError contract and undermines the graceful cloud-failure handling for every pipeline that does not suppress process exceptions.

### The fix

The throw condition now requires at least one error with ShouldThrow true. Non-throwing errors stay diagnostic only, visible in FlowData.Errors. The inner-exception filter is unchanged, so mixed throwing and non-throwing errors still throw with only the throwing ones aggregated.

### Testing

Two new tests in PipelineTest. Only non-throwing errors process without throwing on an unsuppressed pipeline, and mixed errors throw an aggregate containing only the throwing error. Core test suite 242 passed, 0 failed.

### Rollout

No change when suppression is on, when there are no errors, or when any throwing error exists. Callers that relied on the empty AggregateException as an outage signal (none known, it carries no information) would move to inspecting FlowData.Errors.
