### PR TITLE
FIX: Apply IgnoreFlowDataEvidenceFilter when ShareAllEvidence is true

### DIFF
--- a/FiftyOne.Pipeline.Engines.FiftyOne/FlowElements/ShareUsageBase.cs
+++ b/FiftyOne.Pipeline.Engines.FiftyOne/FlowElements/ShareUsageBase.cs
@@ -563,9 +563,9 @@ namespace FiftyOne.Pipeline.Engines.FiftyOne.FlowElements
         /// <see cref="IFlowData"/> instance should be shared or not.
         /// </param>
         /// <param name="shareAllEvidence">
-        /// If true, all evidence will be shared and  
-        /// the blockedHttpHeaders, includedQueryStringParameters and
-        /// ignoreDataEvidenceFilter parameters will be ignored.
+        /// If true, all evidence will be shared and
+        /// the blockedHttpHeaders and includedQueryStringParameters
+        /// parameters will be ignored.
         /// </param>
         /// <param name="failHandler">
         /// Obsolete. This parameter is no longer used.
@@ -650,8 +650,6 @@ namespace FiftyOne.Pipeline.Engines.FiftyOne.FlowElements
                     blockedHttpHeaders, includedQueryStringParameters, false,
                     aspSessionCookieName);
 
-                _ignoreDataEvidenceFilter = ignoreDataEvidenceFilter;
-
                  trackerEvidenceFiler = new EvidenceKeyFilterShareUsageTracker(
                      blockedHttpHeaders, 
                      includedQueryStringParameters, 
@@ -666,6 +664,8 @@ namespace FiftyOne.Pipeline.Engines.FiftyOne.FlowElements
                 _evidenceKeyFilterExclSession = new EvidenceKeyFilterShareUsage();
                 trackerEvidenceFiler = new EvidenceKeyFilterShareUsageTracker();
             }
+
+            _ignoreDataEvidenceFilter = ignoreDataEvidenceFilter;
 
             _tracker = tracker;
             // If no tracker was supplied then create the default one.

--- a/FiftyOne.Pipeline.Engines.FiftyOne/FlowElements/ShareUsageBuilderBase.cs
+++ b/FiftyOne.Pipeline.Engines.FiftyOne/FlowElements/ShareUsageBuilderBase.cs
@@ -355,10 +355,13 @@ namespace FiftyOne.Pipeline.Engines.FiftyOne.FlowElements
         /// set this to "header.user-agent:ABC"
         /// </summary>
         /// <param name="evidenceFilter">
-        /// Comma separated string containing entries in the format 
+        /// Comma separated string containing entries in the format
         /// <code>[evidenceKey]:[evidenceValue]</code>.
         /// Any requests with evidence matching these entries will
         /// not be shared.
+        /// Whitespace around an entry and around a key is ignored.
+        /// The value is taken verbatim from the first colon onwards,
+        /// so it can itself contain colons.
         /// </param>
         /// <returns></returns>
         [DefaultValue("All values are shared")]
@@ -368,13 +371,18 @@ namespace FiftyOne.Pipeline.Engines.FiftyOne.FlowElements
             {
                 foreach (var kvpString in evidenceFilter.Split(','))
                 {
-                    int separatorIndex = kvpString.IndexOf(':');
+                    // Entries are trimmed because a filter is normally
+                    // written with spaces after the separating commas. An
+                    // untrimmed key never matches any evidence and fails
+                    // silently.
+                    var entry = kvpString.Trim();
+                    int separatorIndex = entry.IndexOf(':');
                     if (separatorIndex >= 0)
                     {
                         KeyValuePair<string, string> kvp =
                             new KeyValuePair<string, string>(
-                                kvpString.Substring(0, separatorIndex),
-                                kvpString.Substring(separatorIndex + 1));
+                                entry.Substring(0, separatorIndex).Trim(),
+                                entry.Substring(separatorIndex + 1));
                         IgnoreDataEvidenceFilter.Add(kvp);
                     }
                     else
@@ -382,7 +390,7 @@ namespace FiftyOne.Pipeline.Engines.FiftyOne.FlowElements
                         string msg = string.Format(CultureInfo.InvariantCulture,
                             Messages.MessageShareUsageInvalidConfig,
                             "IgnoreFlowDataEvidenceFilter",
-                            kvpString);
+                            entry);
                         Logger.LogWarning(msg);
                     }
                 }

--- a/FiftyOne.Pipeline.Engines.FiftyOne/FlowElements/ShareUsageBuilderBase.cs
+++ b/FiftyOne.Pipeline.Engines.FiftyOne/FlowElements/ShareUsageBuilderBase.cs
@@ -301,7 +301,8 @@ namespace FiftyOne.Pipeline.Engines.FiftyOne.FlowElements
 
         /// <summary>
         /// Configure the usage sharing element to share all evidence.
-        /// This will override all the other evidence filtering settings.
+        /// This will override the blocked header and included query
+        /// string parameter settings.
         /// </summary>
         /// <param name="shareAll">
         /// If set to true then all evidence will be shared
@@ -367,10 +368,13 @@ namespace FiftyOne.Pipeline.Engines.FiftyOne.FlowElements
             {
                 foreach (var kvpString in evidenceFilter.Split(','))
                 {
-                    if (kvpString.Contains(":"))
+                    int separatorIndex = kvpString.IndexOf(':');
+                    if (separatorIndex >= 0)
                     {
                         KeyValuePair<string, string> kvp =
-                            new KeyValuePair<string, string>(kvpString.Split(':')[0], kvpString.Split(':')[1]);
+                            new KeyValuePair<string, string>(
+                                kvpString.Substring(0, separatorIndex),
+                                kvpString.Substring(separatorIndex + 1));
                         IgnoreDataEvidenceFilter.Add(kvp);
                     }
                     else

--- a/Tests/FiftyOne.Pipeline.Engines.FiftyOne.Tests/FlowElements/ShareUsageElementTests.cs
+++ b/Tests/FiftyOne.Pipeline.Engines.FiftyOne.Tests/FlowElements/ShareUsageElementTests.cs
@@ -601,6 +601,38 @@ namespace FiftyOne.Pipeline.Engines.FiftyOne.Tests.FlowElements
         }
 
         /// <summary>
+        /// Test that the ignore filter is applied when the element is
+        /// configured to share all evidence.
+        /// </summary>
+        [TestMethod]
+        public void ShareUsageElement_IgnoreOnEvidence_ShareAllEvidence()
+        {
+            // Arrange
+            CreateShareUsage(1, 1, 1, new List<string>(), new List<string>(),
+                new List<KeyValuePair<string, string>>()
+                {
+                    new KeyValuePair<string, string>("header.User-Agent", "Azure Traffic Manager Endpoint Monitor")
+                },
+                shareAll: true);
+
+            Dictionary<string, object> evidenceData = new Dictionary<string, object>()
+            {
+                { Core.Constants.EVIDENCE_CLIENTIP_KEY, "1.2.3.4" },
+                { "header.User-Agent", "Azure Traffic Manager Endpoint Monitor" }
+            };
+            var data = MockFlowData.CreateFromEvidence(evidenceData, false);
+
+            // Act
+            _shareUsageElement.Process(data.Object);
+            // Check that the consumer task did not start.
+            Assert.IsNull(_shareUsageElement.SendDataTask);
+
+            // Assert
+            // Check that no HTTP messages were sent.
+            _httpHandler.VerifySendCalled(0);
+        }
+
+        /// <summary>
         /// Check that the usage element can handle invalid xml chars.
         /// </summary>
         /// <param name="config"></param>
@@ -682,6 +714,42 @@ namespace FiftyOne.Pipeline.Engines.FiftyOne.Tests.FlowElements
 
             Assert.AreEqual(0, logger.WarningEntries.Count());
             Assert.AreEqual(0, logger.ErrorEntries.Count());
+        }
+
+        /// <summary>
+        /// Test that a filter value containing colons is parsed in full.
+        /// </summary>
+        [TestMethod]
+        public void ShareUsageBuilder_IgnoreData_ValueWithColons()
+        {
+            var logger = new TestLogger();
+
+            TestShareUsageBuilder builder = new TestShareUsageBuilder(new TestLoggerFactory(), logger, _httpClient);
+            builder.SetIgnoreFlowDataEvidenceFilter(
+                "header.User-Agent:Pingdom.com_bot_version_1.4_(http://www.pingdom.com/)");
+
+            Assert.AreEqual(0, logger.WarningEntries.Count());
+            Assert.HasCount(1, builder.Filter);
+            Assert.AreEqual("header.User-Agent", builder.Filter[0].Key);
+            Assert.AreEqual(
+                "Pingdom.com_bot_version_1.4_(http://www.pingdom.com/)",
+                builder.Filter[0].Value);
+        }
+
+        /// <summary>
+        /// Exposes the parsed ignore filter for assertions.
+        /// </summary>
+        private class TestShareUsageBuilder : ShareUsageBuilder
+        {
+            public TestShareUsageBuilder(
+                ILoggerFactory loggerFactory,
+                ILogger logger,
+                HttpClient httpClient)
+                : base(loggerFactory, logger, httpClient)
+            {
+            }
+
+            public List<KeyValuePair<string, string>> Filter => IgnoreDataEvidenceFilter;
         }
 
         /// <summary>

--- a/Tests/FiftyOne.Pipeline.Engines.FiftyOne.Tests/FlowElements/ShareUsageElementTests.cs
+++ b/Tests/FiftyOne.Pipeline.Engines.FiftyOne.Tests/FlowElements/ShareUsageElementTests.cs
@@ -633,6 +633,43 @@ namespace FiftyOne.Pipeline.Engines.FiftyOne.Tests.FlowElements
         }
 
         /// <summary>
+        /// Test that a request which does not match the ignore filter is
+        /// still shared when the element is configured to share all
+        /// evidence. This guards the opposite direction to
+        /// <see cref="ShareUsageElement_IgnoreOnEvidence_ShareAllEvidence"/>:
+        /// applying the filter must not suppress everything.
+        /// </summary>
+        [TestMethod]
+        public void ShareUsageElement_ShareAllEvidence_FilterDoesNotMatch()
+        {
+            // Arrange
+            CreateShareUsage(1, 1, 1, new List<string>(), new List<string>(),
+                new List<KeyValuePair<string, string>>()
+                {
+                    new KeyValuePair<string, string>("header.User-Agent", "Azure Traffic Manager Endpoint Monitor")
+                },
+                shareAll: true);
+
+            Dictionary<string, object> evidenceData = new Dictionary<string, object>()
+            {
+                { Core.Constants.EVIDENCE_CLIENTIP_KEY, "1.2.3.4" },
+                { "header.User-Agent", "iPhone" }
+            };
+            var data = MockFlowData.CreateFromEvidence(evidenceData, false);
+
+            // Act
+            _shareUsageElement.Process(data.Object);
+            // Wait for the consumer task to finish.
+            WaitForSendDataTask();
+
+            // Assert
+            // Check that one and only one HTTP message was sent.
+            _httpHandler.VerifySendCalled(1);
+            Assert.HasCount(1, _xmlContent);
+            Assert.Contains("iPhone", _xmlContent[0]);
+        }
+
+        /// <summary>
         /// Check that the usage element can handle invalid xml chars.
         /// </summary>
         /// <param name="config"></param>

--- a/Tests/FiftyOne.Pipeline.Engines.FiftyOne.Tests/FlowElements/ShareUsageElementTests.cs
+++ b/Tests/FiftyOne.Pipeline.Engines.FiftyOne.Tests/FlowElements/ShareUsageElementTests.cs
@@ -737,6 +737,29 @@ namespace FiftyOne.Pipeline.Engines.FiftyOne.Tests.FlowElements
         }
 
         /// <summary>
+        /// Test that whitespace around entries and keys is ignored, so a
+        /// filter written with spaces after the commas still matches.
+        /// </summary>
+        [TestMethod]
+        public void ShareUsageBuilder_IgnoreData_WhitespaceAroundEntries()
+        {
+            var logger = new TestLogger();
+
+            TestShareUsageBuilder builder = new TestShareUsageBuilder(new TestLoggerFactory(), logger, _httpClient);
+            builder.SetIgnoreFlowDataEvidenceFilter(
+                " header.User-Agent :Azure Traffic Manager Endpoint Monitor , header.Other:value ");
+
+            Assert.AreEqual(0, logger.WarningEntries.Count());
+            Assert.HasCount(2, builder.Filter);
+            Assert.AreEqual("header.User-Agent", builder.Filter[0].Key);
+            Assert.AreEqual(
+                "Azure Traffic Manager Endpoint Monitor",
+                builder.Filter[0].Value);
+            Assert.AreEqual("header.Other", builder.Filter[1].Key);
+            Assert.AreEqual("value", builder.Filter[1].Value);
+        }
+
+        /// <summary>
         /// Exposes the parsed ignore filter for assertions.
         /// </summary>
         private class TestShareUsageBuilder : ShareUsageBuilder


### PR DESCRIPTION
### **Why:**

- https://github.com/51Degrees/pipeline-dotnet/issues/355

## Problem

`ShareUsageBase` only assigned `_ignoreDataEvidenceFilter` inside the
`if (shareAllEvidence == false)` branch. A deployment that enables
`ShareAllEvidence` therefore left the filter null, and `ProcessInternal`
never excluded anything, so requests the configuration marked as never to
be shared - internal monitors, synthetic and test traffic - were shared
anyway. Nothing was logged, so the configuration silently did nothing.

Secondary problem from the same issue: `SetIgnoreFlowDataEvidenceFilter`
split entries on every colon and kept `Split(':')[1]`, so a value
containing a colon was truncated. For example a monitoring bot's
user-agent of the form `SomeBot_version_1.4_(http://www.example.com/)`
was stored as `SomeBot_version_1.4_(http` and could never match.

Related to that: entries were not trimmed, so a filter written with
spaces after the separating commas produced keys with a leading space,
which likewise never match and log no warning.

## Change

- `ShareUsageBase`: assign `_ignoreDataEvidenceFilter` unconditionally.
  `ShareAllEvidence` keeps controlling which evidence values go into a
  shared record; the ignore filter decides which requests are shared at
  all. Doc comments updated to match the real behaviour.
- `ShareUsageBuilderBase.SetIgnoreFlowDataEvidenceFilter`: split each entry
  at the first colon only (`IndexOf`/`Substring`, the project targets
  netstandard2.0 which has no `Split(char, int)`), and trim whitespace
  around each entry and each key. Values are still taken verbatim from the
  first colon onwards.

This matches `pipeline-java`, which already assigns the filter
unconditionally (`ShareUsageBase.java:424`).

## Behaviour change

A pipeline configured with both `ShareAllEvidence = true` and an
`IgnoreFlowDataEvidenceFilter` previously shared every request. Matching
requests are now excluded, which is what the configuration always claimed
to do. Deployments running both settings will see their shared volume
drop accordingly; this is worth calling out in the release notes.
Configurations without the filter are unaffected (the filter list is
empty, so the check is a no-op).