### PR TITLE
FEAT: Warnings channel on flow data, emitted by the JSON builder

### DIFF
--- a/FiftyOne.Pipeline.Core/Data/FlowData.cs
+++ b/FiftyOne.Pipeline.Core/Data/FlowData.cs
@@ -83,6 +83,21 @@ namespace FiftyOne.Pipeline.Core.Data
         /// Lock to use when adding errors.
         /// </summary>
         private object _errorsLock;
+
+        /// <summary>
+        /// Messages for the caller that did not stop the request being
+        /// served. Created on the first warning, under
+        /// <see cref="_warningsLock"/>.
+        /// </summary>
+        private List<IFlowWarning> _warnings;
+
+        /// <summary>
+        /// Lock to use when adding or reading warnings. Assigned here rather
+        /// than on first use so that concurrent elements cannot each install
+        /// a lock of their own and then add while holding different ones.
+        /// </summary>
+        private readonly object _warningsLock = new object();
+
         private bool disposedValue;
 
         /// <summary>
@@ -286,6 +301,77 @@ namespace FiftyOne.Pipeline.Core.Data
                 }
                 _logger.LogError(ex, logMessage);
             }            
+        }
+
+        /// <summary>
+        /// The warnings that have been recorded during processing, in the
+        /// order they were added. Empty if there are none.
+        /// </summary>
+        /// <remarks>
+        /// A snapshot rather than the live collection, so that a caller
+        /// reading this while a concurrent element is still adding cannot
+        /// observe a partially written list.
+        /// </remarks>
+        public IReadOnlyList<IFlowWarning> Warnings
+        {
+            get
+            {
+                lock (_warningsLock)
+                {
+                    return _warnings == null
+                        ? EmptyWarnings
+                        : _warnings.ToArray();
+                }
+            }
+        }
+
+        private static readonly IFlowWarning[] EmptyWarnings =
+            new IFlowWarning[0];
+
+        /// <summary>
+        /// Record a message for the caller about something that was wrong
+        /// with the request but did not stop it being served.
+        /// </summary>
+        /// <remarks>
+        /// Unlike <see cref="AddError(Exception, IFlowElement)"/> this never
+        /// affects processing: the pipeline does not throw because a warning
+        /// was recorded. Use it for a problem the caller should know about
+        /// and can act on, such as an evidence value that could not be used.
+        /// Safe to call from elements running concurrently.
+        /// </remarks>
+        /// <param name="message">The message for the caller.</param>
+        /// <param name="flowElement">
+        /// The flow element the warning relates to, or null.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if the supplied message is null.
+        /// </exception>
+        public void AddWarning(string message, IFlowElement flowElement)
+        {
+            if (message == null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+            var warning = new FlowWarning(message, flowElement);
+            lock (_warningsLock)
+            {
+                if (_warnings == null)
+                {
+                    _warnings = new List<IFlowWarning>();
+                }
+                _warnings.Add(warning);
+            }
+
+            if (_logger != null && _logger.IsEnabled(LogLevel.Warning))
+            {
+                var logMessage = message;
+                if (flowElement != null)
+                {
+                    logMessage = logMessage
+                        + $" (from {flowElement.GetType().Name})";
+                }
+                _logger.LogWarning(logMessage);
+            }
         }
 
         /// <summary>

--- a/FiftyOne.Pipeline.Core/Data/FlowDataExtensions.cs
+++ b/FiftyOne.Pipeline.Core/Data/FlowDataExtensions.cs
@@ -20,7 +20,9 @@
  * such notice(s) shall fulfill the requirements of that article.
  * ********************************************************************* */
 
+using FiftyOne.Pipeline.Core.FlowElements;
 using System;
+using System.Collections.Generic;
 using System.Threading;
 
 namespace FiftyOne.Pipeline.Core.Data
@@ -117,6 +119,79 @@ namespace FiftyOne.Pipeline.Core.Data
                 data.Stop = true;
 #pragma warning restore CS0618 // Type or member is obsolete
             }
+        }
+
+        /// <summary>
+        /// Record a message for the caller about something that was wrong
+        /// with the request but did not stop it being served, for example an
+        /// evidence value that an element could not use. A builder such as
+        /// the JSON builder writes these into the response.
+        /// </summary>
+        /// <remarks>
+        /// This is the channel to use instead of
+        /// <see cref="IFlowData.AddError(Exception, IFlowElement)"/> for a
+        /// problem that should not fail the request. A non-empty errors
+        /// collection makes the pipeline throw at the end of processing
+        /// unless the host has set SuppressProcessExceptions, whatever the
+        /// shouldThrow flag on the individual error says, which leaves such
+        /// a host returning no payload at all.
+        /// </remarks>
+        /// <param name="data">The flow data to record the message on.</param>
+        /// <param name="message">The message for the caller.</param>
+        /// <param name="flowElement">
+        /// The flow element the warning relates to, or null.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if the supplied data or message is null.
+        /// </exception>
+        public static void AddWarning(
+            this IFlowData data,
+            string message,
+            IFlowElement flowElement)
+        {
+            if (data == null)
+            {
+                throw new ArgumentNullException(nameof(data));
+            }
+            if (message == null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+            if (data is FlowData concrete)
+            {
+                concrete.AddWarning(message, flowElement);
+                return;
+            }
+            // A third-party IFlowData has nowhere to keep the message and no
+            // builder that would read it back, so there is nothing to do.
+            // Every flow data the pipeline creates is a FlowData.
+        }
+
+        /// <summary>
+        /// The messages recorded by
+        /// <see cref="AddWarning(IFlowData, string, IFlowElement)"/>, in the
+        /// order they were added.
+        /// </summary>
+        /// <param name="data">The flow data to read the messages from.</param>
+        /// <returns>
+        /// The warnings, or an empty list if there are none or the flow data
+        /// does not support them.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if the supplied data is null.
+        /// </exception>
+        public static IReadOnlyList<IFlowWarning> GetWarnings(
+            this IFlowData data)
+        {
+            if (data == null)
+            {
+                throw new ArgumentNullException(nameof(data));
+            }
+            if (data is FlowData concrete)
+            {
+                return concrete.Warnings;
+            }
+            return new IFlowWarning[0];
         }
     }
 }

--- a/FiftyOne.Pipeline.Core/Data/FlowWarning.cs
+++ b/FiftyOne.Pipeline.Core/Data/FlowWarning.cs
@@ -1,0 +1,59 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+using FiftyOne.Pipeline.Core.FlowElements;
+using System;
+
+namespace FiftyOne.Pipeline.Core.Data
+{
+    /// <summary>
+    /// Default <see cref="IFlowWarning"/> implementation.
+    /// </summary>
+    public class FlowWarning : IFlowWarning
+    {
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="message">The message for the caller.</param>
+        /// <param name="flowElement">
+        /// The flow element the warning relates to, or null.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if the supplied message is null.
+        /// </exception>
+        public FlowWarning(string message, IFlowElement flowElement)
+        {
+            if (message == null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+            Message = message;
+            FlowElement = flowElement;
+        }
+
+        /// <inheritdoc/>
+        public string Message { get; }
+
+        /// <inheritdoc/>
+        public IFlowElement FlowElement { get; }
+    }
+}

--- a/FiftyOne.Pipeline.Core/Data/IFlowWarning.cs
+++ b/FiftyOne.Pipeline.Core/Data/IFlowWarning.cs
@@ -1,0 +1,52 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+using FiftyOne.Pipeline.Core.FlowElements;
+
+namespace FiftyOne.Pipeline.Core.Data
+{
+    /// <summary>
+    /// Represents something the caller should know about the request that
+    /// did not stop it being served. For example, an evidence value that an
+    /// element could not use.
+    /// </summary>
+    /// <remarks>
+    /// Warnings are deliberately separate from <see cref="IFlowError"/>.
+    /// A non-empty errors collection makes the pipeline throw at the end of
+    /// processing unless the host suppresses process exceptions, so an
+    /// element cannot use an error to explain a recoverable problem without
+    /// risking the whole response. A warning never affects processing.
+    /// </remarks>
+    public interface IFlowWarning
+    {
+        /// <summary>
+        /// The message for the caller.
+        /// </summary>
+        string Message { get; }
+
+        /// <summary>
+        /// The flow element that the warning relates to. May be null if the
+        /// warning did not originate from an element.
+        /// </summary>
+        IFlowElement FlowElement { get; }
+    }
+}

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JsonBuilderElement/FlowElement/JsonBuilderElement.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JsonBuilderElement/FlowElement/JsonBuilderElement.cs
@@ -322,6 +322,7 @@ namespace FiftyOne.Pipeline.JsonBuilder.FlowElement
             }
 
             AddErrors(data, allProperties);
+            AddWarnings(data, allProperties);
 
             try
             {
@@ -503,6 +504,41 @@ namespace FiftyOne.Pipeline.JsonBuilder.FlowElement
 
                 allProperties.Add("errors", errors);
             }
+        }
+
+        /// <summary>
+        /// Add any warnings in the flow data object to the dictionary. These
+        /// tell the caller about something wrong with the request, such as
+        /// an evidence value that could not be used, whilst still returning
+        /// the rest of the data.
+        /// </summary>
+        /// <param name="data"></param>
+        /// <param name="allProperties"></param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if one of the supplied parameters is null
+        /// </exception>
+        protected virtual void AddWarnings(IFlowData data,
+            Dictionary<string, object> allProperties)
+        {
+            if (data == null) throw new ArgumentNullException(nameof(data));
+            if (allProperties == null) throw new ArgumentNullException(nameof(allProperties));
+
+            var warnings = data.GetWarnings();
+            if (warnings.Count == 0)
+            {
+                return;
+            }
+
+            var messages = warnings.Select(w => w.Message);
+            // A subclass may already have written warnings of its own. Add
+            // to them rather than replacing them or throwing on the
+            // duplicate key.
+            if (allProperties.TryGetValue("warnings", out var existing)
+                && existing is IEnumerable<string> existingMessages)
+            {
+                messages = existingMessages.Concat(messages);
+            }
+            allProperties["warnings"] = messages.ToArray();
         }
 
         /// <summary>

--- a/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JsonBuilderElementTests/JsonBuilderElementTests.cs
+++ b/FiftyOne.Pipeline.Elements/FiftyOne.Pipeline.JsonBuilderElementTests/JsonBuilderElementTests.cs
@@ -439,6 +439,117 @@ namespace FiftyOne.Pipeline.JsonBuilderElementTests
         }
 
         /// <summary>
+        /// A message recorded with AddWarning must reach the caller in the
+        /// top level warnings array, with the rest of the data alongside it.
+        /// </summary>
+        [TestMethod]
+        public void JsonBuilder_Warnings_InJson()
+        {
+            const string message = "evidence value 'n2' could not be used";
+
+            var json = ProcessWithWarnings(
+                new JsonBuilderElementBuilder(_loggerFactory).Build(),
+                message);
+
+            var warnings = JObject.Parse(json)["warnings"];
+            Assert.IsNotNull(warnings, "expected a warnings array");
+            CollectionAssert.AreEqual(
+                new[] { message },
+                warnings.Select(w => w.ToString()).ToArray());
+            // The data must still be there. A warning is not an error.
+            Assert.IsNotNull(JObject.Parse(json)["empty-aspect"]);
+        }
+
+        /// <summary>
+        /// With nothing to report there must be no warnings entry, so the
+        /// response shape does not change for the normal case.
+        /// </summary>
+        [TestMethod]
+        public void JsonBuilder_NoWarnings_NoEntryInJson()
+        {
+            var json = ProcessWithWarnings(
+                new JsonBuilderElementBuilder(_loggerFactory).Build());
+
+            Assert.IsNull(JObject.Parse(json)["warnings"]);
+        }
+
+        /// <summary>
+        /// A subclass that already writes warnings of its own keeps them:
+        /// the flow data warnings are added to that entry rather than
+        /// replacing it or throwing on the duplicate key.
+        /// </summary>
+        [TestMethod]
+        public void JsonBuilder_Warnings_MergedWithSubclassEntry()
+        {
+            var json = ProcessWithWarnings(
+                new SubclassWarningJsonBuilderElement(_loggerFactory),
+                "from the flow data");
+
+            var warnings = JObject.Parse(json)["warnings"]
+                .Select(w => w.ToString())
+                .ToArray();
+            CollectionAssert.AreEqual(
+                new[]
+                {
+                    SubclassWarningJsonBuilderElement.Warning,
+                    "from the flow data"
+                },
+                warnings);
+        }
+
+        /// <summary>
+        /// Run a real pipeline built around the supplied JSON builder,
+        /// recording the supplied warnings on the flow data first.
+        /// </summary>
+        /// <param name="jsonBuilder">The JSON builder to use.</param>
+        /// <param name="warnings">The warnings to record.</param>
+        /// <returns>The JSON the builder produced.</returns>
+        private string ProcessWithWarnings(
+            IJsonBuilderElement jsonBuilder,
+            params string[] warnings)
+        {
+            var engine = new EmptyEngineBuilder(_loggerFactory).Build();
+            var sequenceElement = new SequenceElementBuilder(_loggerFactory)
+                .Build();
+            var pipeline = new PipelineBuilder(_loggerFactory)
+                .AddFlowElement(sequenceElement)
+                .AddFlowElement(engine)
+                .AddFlowElement(jsonBuilder)
+                .Build();
+
+            using (var flowData = pipeline.CreateFlowData())
+            {
+                foreach (var warning in warnings)
+                {
+                    flowData.AddWarning(warning, engine);
+                }
+                flowData.Process();
+                return flowData.Get<IJsonBuilderElementData>().Json;
+            }
+        }
+
+        /// <summary>
+        /// Inner class standing in for a builder that already produces its
+        /// own warnings entry, as a subclass in another repository does.
+        /// </summary>
+        private class SubclassWarningJsonBuilderElement : TestJsonBuilderElement
+        {
+            public const string Warning = "from the subclass";
+
+            public SubclassWarningJsonBuilderElement(
+                ILoggerFactory loggerFactory)
+                : base(loggerFactory)
+            { }
+
+            protected override void AddErrors(IFlowData data,
+                Dictionary<string, object> allProperties)
+            {
+                base.AddErrors(data, allProperties);
+                allProperties["warnings"] = new string[] { Warning };
+            }
+        }
+
+        /// <summary>
         /// Inner class used to test serialization of values in 
         /// isolation
         /// </summary>

--- a/Tests/FiftyOne.Pipeline.Core.Tests/Data/FlowDataTests.cs
+++ b/Tests/FiftyOne.Pipeline.Core.Tests/Data/FlowDataTests.cs
@@ -1070,5 +1070,144 @@ namespace FiftyOne.Pipeline.Core.Tests.Data
 
             DisposeFlowData();
         }
+
+        #region Warnings
+
+        /// <summary>
+        /// A flow data that nothing has warned about has no warnings.
+        /// </summary>
+        [TestMethod]
+        public void FlowData_Warnings_NoneByDefault()
+        {
+            Assert.IsEmpty(_flowData.Warnings);
+            Assert.IsEmpty(((IFlowData)_flowData).GetWarnings());
+        }
+
+        /// <summary>
+        /// A recorded warning is readable, in order, with the element that
+        /// recorded it.
+        /// </summary>
+        [TestMethod]
+        public void FlowData_Warnings_Added()
+        {
+            var element = new Mock<IFlowElement>();
+
+            _flowData.AddWarning("first", element.Object);
+            _flowData.AddWarning("second", null);
+
+            var warnings = _flowData.Warnings;
+            Assert.HasCount(2, warnings);
+            Assert.AreEqual("first", warnings[0].Message);
+            Assert.AreEqual(element.Object, warnings[0].FlowElement);
+            Assert.AreEqual("second", warnings[1].Message);
+            Assert.IsNull(warnings[1].FlowElement);
+        }
+
+        /// <summary>
+        /// A warning must not make the pipeline throw the way an error does,
+        /// which is the whole reason for the collection existing.
+        /// </summary>
+        [TestMethod]
+        public void FlowData_Warnings_NotAddedToErrors()
+        {
+            _flowData.AddWarning("a warning", null);
+
+            Assert.IsTrue(
+                _flowData.Errors == null || _flowData.Errors.Count == 0);
+        }
+
+        /// <summary>
+        /// The returned collection is a snapshot, so a caller holding it
+        /// while further warnings are recorded does not see them appear.
+        /// </summary>
+        [TestMethod]
+        public void FlowData_Warnings_IsSnapshot()
+        {
+            _flowData.AddWarning("first", null);
+            var warnings = _flowData.Warnings;
+
+            _flowData.AddWarning("second", null);
+
+            Assert.HasCount(1, warnings);
+            Assert.HasCount(2, _flowData.Warnings);
+        }
+
+        /// <summary>
+        /// A null message is a caller error rather than something to record.
+        /// </summary>
+        [TestMethod]
+        public void FlowData_Warnings_NullMessage()
+        {
+            Assert.ThrowsExactly<ArgumentNullException>(
+                () => _flowData.AddWarning(null, null));
+        }
+
+        /// <summary>
+        /// Elements in a ParallelElements group can warn at the same time,
+        /// so no warning may be lost and the collection may not be observed
+        /// part-written. This is the requirement the collection exists to
+        /// meet - see 51Degrees/pipeline-dotnet#363.
+        /// </summary>
+        [TestMethod]
+        public void FlowData_Warnings_AddedConcurrently()
+        {
+            const int threads = 8;
+            const int perThread = 250;
+            var start = new ManualResetEventSlim(false);
+            var readerFailure = 0;
+
+            var writers = Enumerable.Range(0, threads).Select(t =>
+            {
+                var thread = new Thread(() =>
+                {
+                    start.Wait();
+                    for (var i = 0; i < perThread; i++)
+                    {
+                        _flowData.AddWarning($"{t}-{i}", null);
+                    }
+                });
+                thread.Start();
+                return thread;
+            }).ToList();
+
+            // Read throughout, so a reader overlapping a writer is covered
+            // as well as writers overlapping each other.
+            var reader = new Thread(() =>
+            {
+                start.Wait();
+                for (var i = 0; i < 500; i++)
+                {
+                    try
+                    {
+                        foreach (var warning in _flowData.Warnings)
+                        {
+                            if (warning == null)
+                            {
+                                Interlocked.Increment(ref readerFailure);
+                            }
+                        }
+                    }
+                    catch (InvalidOperationException)
+                    {
+                        Interlocked.Increment(ref readerFailure);
+                    }
+                }
+            });
+            reader.Start();
+
+            start.Set();
+            foreach (var thread in writers)
+            {
+                thread.Join();
+            }
+            reader.Join();
+
+            Assert.AreEqual(0, readerFailure,
+                "Reading the warnings while they were being added failed.");
+            Assert.HasCount(threads * perThread, _flowData.Warnings,
+                "Warnings were lost when several threads recorded them.");
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
Implements #363. Draft: the shape of the API is the thing to agree before it is worth polishing.

## Why

An element that finds something wrong with the request cannot tell the caller without failing it. `Errors` is not usable for a non-fatal problem - `Pipeline.Process` throws whenever the collection is non-empty and the host has not set `SuppressProcessExceptions`, whatever `shouldThrow` says on the individual error - so a consumer that wants to explain a bad evidence value has to build its own channel. The only construction available is an `ElementDataBase` subclass stashed on the flow data, which `JsonBuilderElement.GetAllProperties` then serialises into the response, and which has no stated threading contract. Both are framework properties, so both are fixed here rather than once per consumer.

## What changed

- `IFlowWarning` / `FlowWarning`, and `Warnings` / `AddWarning` on `FlowData`.
- `AddWarning` / `GetWarnings` extension methods on `IFlowData` in `FlowDataExtensions`.
- `JsonBuilderElement.AddWarnings` writes the messages to a top level `warnings` array, called from `BuildJson` right after `AddErrors`.

Two things worth a reviewer's attention rather than being buried in the diff.

**`IFlowData` is unchanged.** The members are on the concrete `FlowData`, reached through extension methods that cast, which is the approach the stop token took for the same reason - no major version bump. The cost is that a mocked `IFlowData` carries no warnings, so a test that mocks the interface and expects an element's warning to reach the JSON will see nothing. Putting the members on the interface, as #363 sketched, is cleaner and breaking; say which you would rather have.

**Synchronisation is the requirement, not a detail.** The lock is assigned in the field initialiser rather than on first use, so two elements in a `ParallelElements` group cannot each install a lock and then add to the same list while holding different ones. Reading returns a snapshot taken under that lock. This is deliberately not how `AddError` does it - the lazy initialisation there is the race described in #362, which this does not touch.

`AddWarnings` merges rather than overwrites, so a subclass that already writes a `warnings` entry of its own keeps it. Without that, a subclass gets either an `ArgumentException` on the duplicate key or silent loss depending on which of `Add` or the indexer is used.

## Testing

`FiftyOne.Pipeline.Core.Tests` 283/283 and `FiftyOne.Pipeline.JsonBuilderElementTests` 273/273 pass locally.

New coverage: warnings recorded and read back with the element that recorded them, the snapshot semantics, the null message guard, and that a warning does not reach `Errors`. `FlowData_Warnings_AddedConcurrently` has eight threads recording while a ninth reads throughout, asserting no warning is lost and no read fails. It was checked against a deliberately unsynchronised implementation of `AddWarning` first, where it fails - a concurrency test that has never been seen to fail is not evidence of anything.

On the builder side: the message reaching the `warnings` array with the rest of the data still present, no `warnings` entry when nothing warned, and the merge with a subclass entry.

## Not included

- The `AddError` initialisation race and the wider threading audit (#362).
- Other language ports and the response specification. If `warnings` is accepted as part of the JSON response shape, they should follow.
- Duplicate suppression. `Errors` does not deduplicate either, so neither does this; worth deciding rather than assuming.
